### PR TITLE
fix: add missing [req] section to openssl.cnf

### DIFF
--- a/server/probe.py
+++ b/server/probe.py
@@ -4426,7 +4426,9 @@ def create_old_protossl_cert_files(hostname: str, directory: Path, force: bool =
         "[provider_sect]\ndefault = default_sect\nlegacy = legacy_sect\n"
         "[default_sect]\nactivate = 1\n[legacy_sect]\nactivate = 1\n"
         "[algorithm_sect]\n[ssl_sect]\nsystem_default = system_default_sect\n"
-        "[system_default_sect]\nCipherString = DEFAULT:@SECLEVEL=0\nMinProtocol = TLSv1\n",
+        "[system_default_sect]\nCipherString = DEFAULT:@SECLEVEL=0\nMinProtocol = TLSv1\n"
+        "[req]\ndistinguished_name = req_distinguished_name\nprompt = no\n"
+        "[req_distinguished_name]\n",
         encoding="ascii",
     )
 


### PR DESCRIPTION
## What changed?
`create_old_protossl_cert_files()` in `server/probe.py` generates a temporary OpenSSL config file (`openssl-old-protossl.cnf`) used to create the legacy CA/cert for old EA ProtoSSL. That generated config has no `[req]` section. Some OpenSSL builds (I hit this with the OpenSSL bundled in Git for Windows, `mingw64/bin/openssl.exe`) require a `distinguished_name` key under `[req]` even when `-subj` is passed on the command line, so `openssl req -x509 ...` fails immediately with:
 
```
unable to find 'distinguished_name' in config
problems making Certificate Request
```
 
This causes the launcher to fail before it ever reaches READY, on the very first run. This PR adds a minimal `[req]` / `[req_distinguished_name]` section to the generated config so CA creation succeeds regardless of which OpenSSL build is on PATH, without changing any of the actual certificate values (those are still set via `-subj` and the other CLI args as before).
 
## Testing
- [x] Python files compile successfully.
- [ ] JSON data files parse successfully. (N/A — no JSON files touched)
- [x] I did not add generated runtime state, certificates, secrets, or EA game files.
- [x] I documented any FIFA/runtime test I performed.
## Runtime test notes
Ran `RUN_FIFA14_LOCAL_BETA.cmd` as Administrator on Windows with FIFA 14 installed at the default EA Games path. Before this fix, the launcher consistently failed at CA creation with the OpenSSL error above (using Git for Windows' bundled OpenSSL 1.1.1, found via `find_openssl()`), and the process exited with "BETA FAILED" before reaching the game. After applying this fix and clearing the stale `artifacts\local-old-protossl` folder, it ran successfully and i was able to launch fifa, and use all the current functionality
