### PR TITLE
Fix worktree-aware repo setup scripts

### DIFF
--- a/PUSH_TO_GITHUB.cmd
+++ b/PUSH_TO_GITHUB.cmd
@@ -15,7 +15,8 @@ if errorlevel 1 (
   exit /b 1
 )
 
-if not exist ".git\" (
+git rev-parse --git-dir >nul 2>nul
+if errorlevel 1 (
   echo [ERROR] This folder is not initialised yet.
   echo Run SETUP_GITHUB_REPO.cmd first.
   pause
@@ -41,13 +42,17 @@ if errorlevel 1 (
 )
 if errorlevel 1 goto :failed
 
-git branch -M main
-if errorlevel 1 goto :failed
+for /f "delims=" %%B in ('git branch --show-current 2^>nul') do set "CURRENT_BRANCH=%%B"
+
+if "%CURRENT_BRANCH%"=="" (
+  echo [ERROR] Unable to determine the current branch.
+  goto :failed
+)
 
 echo.
-echo Pushing main branch...
+echo Pushing branch '%CURRENT_BRANCH%' to GitHub as 'main'...
 echo Git for Windows may open a browser window for GitHub sign-in.
-git push -u origin main
+git push -u origin "HEAD:main"
 if errorlevel 1 goto :failed
 
 echo.

--- a/SETUP_GITHUB_REPO.cmd
+++ b/SETUP_GITHUB_REPO.cmd
@@ -16,7 +16,8 @@ if errorlevel 1 (
   exit /b 1
 )
 
-if exist ".git\" (
+git rev-parse --git-dir >nul 2>nul
+if not errorlevel 1 (
   echo [INFO] This folder is already a Git repository.
 ) else (
   echo [1/3] Initialising repository...


### PR DESCRIPTION
## What changed?

This fixes the Git bootstrap scripts for this repo when it is opened as a Git worktree instead of a normal checkout. The previous checks used `.git\` directory logic, which fails for worktrees because the working tree points to a `.git` file that contains a `gitdir:` entry.

The change makes both setup and push detection use Git's own repository check (`git rev-parse --git-dir`) and updates the push flow to push the current branch HEAD to `main` without forcing a branch rename that is invalid in linked worktrees.

## Testing

- [x] Python files compile successfully.
- [ ] JSON data files parse successfully.
- [x] I did not add generated runtime state, certificates, secrets, or EA game files.
- [x] I documented any FIFA/runtime test I performed.

## Runtime test notes

Validated the worktree-safe Git logic by running the repository setup and push scripts in this environment. The push script now reaches the remote push step and only fails when the target GitHub repository URL is not valid or the current account lacks write access. No FIFA runtime launch was performed here because this change is limited to Git bootstrap script behavior.