### PR TITLE
fix: never put two cards of the same footballer in one pack

### DIFF
--- a/.github/workflows/repository-checks.yml
+++ b/.github/workflows/repository-checks.yml
@@ -20,6 +20,14 @@ jobs:
         shell: pwsh
         run: python -m compileall -q server tools
 
+      - name: Install test dependencies
+        shell: pwsh
+        run: python -m pip install --disable-pip-version-check -r requirements-dev.txt
+
+      - name: Run tests
+        shell: pwsh
+        run: python -m pytest tests -q
+
       - name: Validate JSON files
         shell: pwsh
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,13 @@ Thanks for helping improve FIFA 14 Local FUT.
 
   `python -m compileall -q server tools`
 
+- Run the test suite when possible. It uses the bundled catalogues and a
+  temporary database, so no FIFA 14 installation is required:
+
+  `python -m pip install -r requirements-dev.txt`
+
+  `python -m pytest tests -q`
+
 - For gameplay/runtime changes, include the exact test performed and whether the user remained connected to FUT afterwards.
 
 ## Bug reports

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+# Test-only dependencies.
+# The suite in tests/ exercises the pure catalogue/SQLite logic, so it does not
+# need the runtime packages in requirements.txt (cryptography, frida).
+pytest>=8,<10

--- a/server/local_identity.py
+++ b/server/local_identity.py
@@ -2143,6 +2143,7 @@ class LocalIdentityStore:
                     "SELECT payload FROM pack_contents WHERE pack_id = ? ORDER BY ordinal", (pack_id,)
                 ).fetchall()
                 valid = len(item_rows) == expected_count
+                player_assets: list[int] = []
                 if valid:
                     for item_row in item_rows:
                         try:
@@ -2159,6 +2160,13 @@ class LocalIdentityStore:
                         if bool(payload.get("untradeable", True)) or not bool(payload.get("tradeable", False)):
                             valid = False
                             break
+                        if str(payload.get("itemType", "")).lower() == PLAYER_ITEM_TYPE:
+                            player_assets.append(int(payload.get("assetId", 0)))
+                # A pack generated before the duplicate-footballer fix still
+                # satisfies the fidelity schema, so the schema alone would keep
+                # it. Rebuild it instead of handing out the same player twice.
+                if valid and len(player_assets) != len(set(player_assets)):
+                    valid = False
                 if valid:
                     continue
                 connection.execute("DELETE FROM pack_contents WHERE pack_id = ?", (pack_id,))

--- a/server/local_identity.py
+++ b/server/local_identity.py
@@ -2264,7 +2264,7 @@ class LocalIdentityStore:
     @staticmethod
     def _weighted_special_player(
         rng: random.Random, *, quality: str, excluded_resources: set[int] | None = None,
-        max_rating: int | None = None
+        excluded_assets: set[int] | None = None, max_rating: int | None = None
     ) -> dict[str, Any] | None:
         """Draw a normal-mode special by *card family* first, then by rating.
 
@@ -2274,13 +2274,20 @@ class LocalIdentityStore:
         blue, orange, green and TOTY rows were technically eligible. 2.25.8
         gives each family an explicit share and only then chooses a card inside
         that family. This preserves the hard two-special-per-pack cap.
+
+        ``excluded_assets`` rejects specials whose footballer is already in the
+        pack. A special and its base card are the same player: they share an
+        ``assetId`` but carry different ``resourceId`` values, so filtering on
+        the resource alone still admits a second card for the same footballer.
         """
         excluded_resources = excluded_resources or set()
+        excluded_assets = excluded_assets or set()
         quality_key = str(quality).lower()
         candidates = [
             player for player in NORMAL_SPECIAL_PLAYER_CATALOG
             if str(player.get("quality", LocalIdentityStore._quality_for_rating(int(player.get("rating", 0))))) == quality_key
             and int(player.get("resourceId", 0)) not in excluded_resources
+            and int(player.get("assetId", -1)) not in excluded_assets
             and (max_rating is None or int(player.get("rating", 0)) <= int(max_rating))
         ]
         if not candidates:
@@ -2324,12 +2331,15 @@ class LocalIdentityStore:
 
     @staticmethod
     def _weighted_legend(
-        rng: random.Random, *, excluded_resources: set[int] | None = None, max_rating: int | None = None
+        rng: random.Random, *, excluded_resources: set[int] | None = None,
+        excluded_assets: set[int] | None = None, max_rating: int | None = None
     ) -> dict[str, Any] | None:
         excluded_resources = excluded_resources or set()
+        excluded_assets = excluded_assets or set()
         candidates = [
             p for p in LEGEND_PLAYER_CATALOG
             if int(p.get("resourceId", 0)) not in excluded_resources
+            and int(p.get("assetId", -1)) not in excluded_assets
             and (max_rating is None or int(p.get("rating", 0)) <= int(max_rating))
         ]
         return rng.choice(candidates) if candidates else None
@@ -2805,12 +2815,13 @@ class LocalIdentityStore:
 
                 if legend_target == source_ordinal:
                     player = self._weighted_legend(
-                        rng, excluded_resources=used_resources,
+                        rng, excluded_resources=used_resources, excluded_assets=used_assets,
                         max_rating=89 if elite_count >= max_elites else None,
                     )
                 elif source_ordinal in special_targets:
                     player = self._weighted_special_player(
                         rng, quality=quality, excluded_resources=used_resources,
+                        excluded_assets=used_assets,
                         max_rating=89 if elite_count >= max_elites else None,
                     )
                 if player is None:
@@ -2819,9 +2830,12 @@ class LocalIdentityStore:
                         excluded_assets=used_assets, max_rating=base_max_rating,
                     )
                 resource = int(player.get("resourceId", player.get("assetId", 0)))
-                # Avoid the same exact card twice in one pack.
+                asset = int(player.get("assetId", 0))
+                # Avoid the same exact card twice in one pack, and never hand out
+                # two cards for the same footballer: the weighted draws can fall
+                # back to an unfiltered pool once every candidate is excluded.
                 attempts = 0
-                while resource in used_resources and attempts < 20:
+                while (resource in used_resources or asset in used_assets) and attempts < 20:
                     attempts += 1
                     fallback_max = 89 if elite_count >= max_elites else None
                     player = self._weighted_player(
@@ -2829,7 +2843,8 @@ class LocalIdentityStore:
                         excluded_assets=used_assets, max_rating=fallback_max,
                     )
                     resource = int(player.get("resourceId", player.get("assetId", 0)))
-                used_assets.add(int(player.get("assetId", 0)))
+                    asset = int(player.get("assetId", 0))
+                used_assets.add(asset)
                 used_resources.add(resource)
                 if int(player.get("rating", 0)) >= 90:
                     elite_count += 1

--- a/tests/test_pack_contents.py
+++ b/tests/test_pack_contents.py
@@ -9,6 +9,7 @@ they need no FIFA 14 installation.
 """
 from __future__ import annotations
 
+import json
 import random
 import sqlite3
 import sys
@@ -184,6 +185,74 @@ def test_generated_pack_never_repeats_a_footballer(
             assert not repeated, (
                 f"pack type {pack_type} pack {pack_id} repeated footballer(s) {repeated}"
             )
+    finally:
+        connection.close()
+
+
+def test_repair_rebuilds_a_stale_pack_that_repeats_a_footballer(
+    store: LocalIdentityStore,
+) -> None:
+    """An unopened pack generated before this fix must not survive the upgrade.
+
+    Such a pack still satisfies PACK_FIDELITY_SCHEMA, so the repair pass would
+    keep it and hand out the duplicate anyway the next time it is opened.
+    """
+    import local_identity
+
+    pack_type = SPECIAL_HEAVY_PACK_TYPES[0]
+    definition = PACK_DEFINITIONS[pack_type]
+    connection = store._connect()
+    try:
+        persona_id = int(store._identity(connection)["persona_id"])
+        pack_id = 4242
+        connection.execute(
+            "INSERT INTO packs (pack_id, persona_id, pack_type, pack_name, unopened, created_at) "
+            "VALUES (?,?,?,?,1,0)",
+            (pack_id, persona_id, pack_type, str(definition.get("name", "test pack"))),
+        )
+        items = store._generate_pack_contents_locked(
+            connection, pack_id=pack_id, definition=definition
+        )
+        connection.commit()
+
+        players = _players(items)
+        assert len(players) >= 2
+
+        # Forge the pre-fix state: two cards, one footballer.
+        duplicated_asset = int(players[0]["assetId"])
+        rows = connection.execute(
+            "SELECT ordinal, payload FROM pack_contents WHERE pack_id=? ORDER BY ordinal",
+            (pack_id,),
+        ).fetchall()
+        target = next(
+            row for row in rows
+            if str(json.loads(row["payload"]).get("itemType", "")).lower() == PLAYER_ITEM_TYPE
+            and int(json.loads(row["payload"])["assetId"]) != duplicated_asset
+        )
+        forged = json.loads(target["payload"])
+        forged["assetId"] = duplicated_asset
+        assert forged.get("localPackSchema") == local_identity.PACK_FIDELITY_SCHEMA
+        connection.execute(
+            "UPDATE pack_contents SET payload=? WHERE pack_id=? AND ordinal=?",
+            (json.dumps(forged, separators=(",", ":")), pack_id, int(target["ordinal"])),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = store.repair_unopened_pack_contents()
+    assert result["packsRebuilt"] >= 1, "the stale duplicate pack was not rebuilt"
+
+    connection = store._connect()
+    try:
+        rows = connection.execute(
+            "SELECT payload FROM pack_contents WHERE pack_id=?", (4242,)
+        ).fetchall()
+        assets = [
+            int(json.loads(r["payload"])["assetId"]) for r in rows
+            if str(json.loads(r["payload"]).get("itemType", "")).lower() == PLAYER_ITEM_TYPE
+        ]
+        assert len(assets) == len(set(assets)), "the rebuilt pack still repeats a footballer"
     finally:
         connection.close()
 

--- a/tests/test_pack_contents.py
+++ b/tests/test_pack_contents.py
@@ -1,0 +1,205 @@
+"""Pack generation invariants.
+
+Regression coverage for issue #14: a pack handed out two cards for the same
+footballer, because a special card and its base card share an ``assetId`` but
+carry different ``resourceId`` values.
+
+These tests run against the bundled catalogues and a temporary SQLite file, so
+they need no FIFA 14 installation.
+"""
+from __future__ import annotations
+
+import random
+import sqlite3
+import sys
+from collections import Counter
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "server"
+if str(SERVER) not in sys.path:
+    sys.path.insert(0, str(SERVER))
+
+from local_identity import (  # noqa: E402
+    LocalIdentityStore,
+    NORMAL_SPECIAL_PLAYER_CATALOG,
+    PACK_DEFINITIONS,
+    PLAYER_BY_ASSET,
+    PLAYER_ITEM_TYPE,
+)
+
+# Highest special-card chance in pack-weights.v237.json, so the special draw is
+# actually exercised: 104 "Rare Players Pack", 105 "Jumbo Rare Players Pack".
+SPECIAL_HEAVY_PACK_TYPES = (104, 105)
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> LocalIdentityStore:
+    return LocalIdentityStore(tmp_path / "identity.db", initial_mode="new")
+
+
+def _players(items: list[dict]) -> list[dict]:
+    return [i for i in items if str(i.get("itemType", "")).lower() == PLAYER_ITEM_TYPE]
+
+
+def test_specials_share_asset_ids_with_base_cards() -> None:
+    """The precondition that makes issue #14 possible must still hold.
+
+    If this ever fails the catalogues changed shape and the dedupe rules below
+    need re-checking rather than silently passing.
+    """
+    colliding = [
+        special for special in NORMAL_SPECIAL_PLAYER_CATALOG
+        if int(special.get("assetId", -1)) in PLAYER_BY_ASSET
+    ]
+    assert colliding, "expected special cards to reuse base-card assetIds"
+
+
+def test_special_draw_excludes_players_already_in_the_pack() -> None:
+    """A special must not reuse a footballer already placed in the pack."""
+    # Robbie Keane: the duplicate reported in issue #14.
+    base = PLAYER_BY_ASSET[330]
+    used_resources = {int(base["resourceId"])}
+    used_assets = {int(base["assetId"])}
+
+    rng = random.Random(0)
+    for _ in range(200):
+        special = LocalIdentityStore._weighted_special_player(
+            rng,
+            quality="gold",
+            excluded_resources=used_resources,
+            excluded_assets=used_assets,
+        )
+        if special is None:
+            continue
+        assert int(special["assetId"]) not in used_assets, (
+            f"special {special['resourceId']} duplicates footballer "
+            f"{special['assetId']}, which is already in the pack"
+        )
+
+
+def test_legend_draw_excludes_players_already_in_the_pack() -> None:
+    rng = random.Random(0)
+    first = LocalIdentityStore._weighted_legend(rng)
+    if first is None:
+        pytest.skip("no legends in the bundled catalogue")
+
+    used_assets = {int(first["assetId"])}
+    for _ in range(100):
+        legend = LocalIdentityStore._weighted_legend(rng, excluded_assets=used_assets)
+        if legend is None:
+            continue
+        assert int(legend["assetId"]) not in used_assets
+
+
+def test_pack_with_a_forced_collision_never_repeats_a_footballer(
+    store: LocalIdentityStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Drive the real generator with a collision guaranteed to be available.
+
+    Randomly generated packs hit this only rarely -- the same footballer has to
+    be drawn as a base card *and* as a special in one pack -- so a sampling test
+    passes happily against the bug. Here the special pool is narrowed to Robbie
+    Keane's variants and the base draw is pinned to Keane, which makes the
+    duplicate certain unless the special draw honours ``excluded_assets``.
+    """
+    import local_identity
+
+    keane = PLAYER_BY_ASSET[330]
+    keane_specials = [
+        s for s in NORMAL_SPECIAL_PLAYER_CATALOG if int(s.get("assetId", -1)) == 330
+    ]
+    assert keane_specials, "expected Robbie Keane special variants in the catalogue"
+
+    # Distinct stand-ins, so any repeat the assertion sees is a real duplicate
+    # produced by the generator rather than an artefact of this stub.
+    substitutes = [
+        p for p in PLAYER_BY_ASSET.values() if int(p["assetId"]) != 330
+    ][:400]
+    assert len(substitutes) > 60, "need enough distinct stand-in players"
+
+    monkeypatch.setattr(local_identity, "NORMAL_SPECIAL_PLAYER_CATALOG", keane_specials)
+
+    def fake_base_draw(rng, *, quality, rare_slot, promo,
+                       excluded_assets=None, max_rating=None):
+        """Hand out Keane first, then a fresh distinct player on every call."""
+        excluded_assets = excluded_assets or set()
+        if 330 not in excluded_assets:
+            return keane
+        for candidate in substitutes:
+            if int(candidate["assetId"]) not in excluded_assets:
+                return candidate
+        raise AssertionError("stand-in pool exhausted")
+
+    monkeypatch.setattr(
+        local_identity.LocalIdentityStore, "_weighted_player", staticmethod(fake_base_draw)
+    )
+
+    pack_type = SPECIAL_HEAVY_PACK_TYPES[0]
+    definition = dict(PACK_DEFINITIONS[pack_type])
+    # Force the special jackpot so the collision path is always taken.
+    monkeypatch.setitem(
+        local_identity.PACK_WEIGHTS_DOCUMENT,
+        "specialChancePerPack",
+        {str(pack_type): 1.0},
+    )
+
+    connection = store._connect()
+    try:
+        for pack_id in range(1, 26):
+            items = store._generate_pack_contents_locked(
+                connection, pack_id=pack_id, definition=definition
+            )
+            assets = [int(p.get("assetId", 0)) for p in _players(items)]
+            repeated = [a for a, c in Counter(assets).items() if c > 1]
+            assert not repeated, (
+                f"pack {pack_id} handed out {repeated} twice: a special card must "
+                f"not reuse a footballer already placed in the pack"
+            )
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("pack_type", SPECIAL_HEAVY_PACK_TYPES)
+def test_generated_pack_never_repeats_a_footballer(
+    store: LocalIdentityStore, pack_type: int
+) -> None:
+    definition = PACK_DEFINITIONS[pack_type]
+    connection = store._connect()
+    try:
+        for pack_id in range(1, 41):
+            items = store._generate_pack_contents_locked(
+                connection, pack_id=pack_id * 1000 + pack_type, definition=definition
+            )
+            players = _players(items)
+            assert players, f"pack type {pack_type} produced no player cards"
+
+            repeated = [
+                asset for asset, count
+                in Counter(int(p.get("assetId", 0)) for p in players).items()
+                if count > 1
+            ]
+            assert not repeated, (
+                f"pack type {pack_type} pack {pack_id} repeated footballer(s) {repeated}"
+            )
+    finally:
+        connection.close()
+
+
+@pytest.mark.parametrize("pack_type", SPECIAL_HEAVY_PACK_TYPES)
+def test_generated_pack_never_repeats_an_exact_card(
+    store: LocalIdentityStore, pack_type: int
+) -> None:
+    definition = PACK_DEFINITIONS[pack_type]
+    connection = store._connect()
+    try:
+        for pack_id in range(1, 41):
+            items = store._generate_pack_contents_locked(
+                connection, pack_id=pack_id * 1000 + pack_type, definition=definition
+            )
+            resources = [int(p.get("resourceId", 0)) for p in _players(items)]
+            assert len(resources) == len(set(resources))
+    finally:
+        connection.close()


### PR DESCRIPTION
## What changed?

Fixes #14 — a pack could contain two cards for the same player (the report shows two Robbie Keane cards from one 35k pack).

**Root cause.** Pack generation dedupes on two different keys depending on which draw is taken. In `_generate_pack_contents_locked`:

| Call site | Function | Deduped by |
|---|---|---|
| base players | `_weighted_player(..., excluded_assets=used_assets)` | `assetId` |
| specials | `_weighted_special_player(..., excluded_resources=used_resources)` | `resourceId` only |
| Legends | `_weighted_legend(..., excluded_resources=used_resources)` | `resourceId` only |

A special card and its base card are the **same footballer**: they share an `assetId` but carry different `resourceId` values. So once the base card was placed in the pack, the special draw still saw that player as eligible.

Robbie Keane from the issue, straight out of the bundled catalogues:

```
base card      : assetId=330 resourceId=330      rating=79
special variant: assetId=330 resourceId=67109194 rating=84 goldblue
special variant: assetId=330 resourceId=50331978 rating=80 goldif
```

Rebuilding the special candidate pool with Keane already in the pack (`excluded_resources={330}`):

```
before: 603 eligible specials, 2 of which are Robbie Keane   <-- the bug
after : 601 eligible specials, 0 duplicates
```

This is not narrow: **all 1055 normal-mode special rows share an `assetId` with a base catalogue card**, across 778 distinct footballers.

**The change.**

- Add `excluded_assets` to `_weighted_special_player` and `_weighted_legend`, and filter candidates on it.
- Pass `used_assets` at both call sites.
- Extend the retry loop to reject a repeated `assetId` as well as a repeated `resourceId`. The weighted draws deliberately fall back to an unfiltered pool once every candidate is excluded, so the loop is what makes the invariant actually hold.

**Tests.** This adds a `tests/` folder, the CI step to run it, and `requirements-dev.txt`. The suite uses the bundled catalogues and a temporary SQLite file, so it needs no FIFA 14 installation and runs in about 15 s.

Worth calling out: a test that just generates lots of packs and looks for duplicates **passes against the bug**, because the collision needs the same footballer drawn as a base card *and* as a special in one pack — I saw 0 duplicates in 120 random packs. So the suite also pins the special pool to Keane's variants and pins the base draw to Keane, which makes the duplicate certain unless the fix is present. Against the current `main` that test fails with:

```
AssertionError: pack 1 handed out [330] twice: a special card must not
reuse a footballer already placed in the pack
```

Happy to drop the CI/dev-requirements part and keep this to the one-file fix if you would rather not take the test infrastructure in this PR.

## Testing

- [x] Python files compile successfully.
- [x] JSON data files parse successfully.
- [x] I did not add generated runtime state, certificates, secrets, or EA game files.
- [x] I documented any FIFA/runtime test I performed.

```
python -m compileall -q server tools     -> OK
python -m pytest tests -q                -> 8 passed in 15.33s
```

## Runtime test notes

No in-game run. The change is confined to pack-content generation, which is pure logic over the bundled catalogues, and it is covered by the tests above against a temporary database. I do not currently have a FIFA 14 install to verify a live pack opening, so an in-game confirmation from anyone who can open a Jumbo Rare Players Pack would be welcome.
