### PR TITLE
fix: do not advertise a saved tournament without a bracket blob

### DIFF
--- a/server/beta_identity.py
+++ b/server/beta_identity.py
@@ -2488,7 +2488,16 @@ class BetaIdentityStore(LocalIdentityStore):
         progressData is four zero bytes (``AAAAAA==``). That state is not a
         playable saved bracket and crashes when reopened. Only later rounds or
         non-zero opaque progress bytes are advertised as resumable.
+
+        A saved round is also worthless without the bracket itself. When the
+        server advances the round after a won match it deliberately does not
+        invent a tournamentData blob, so an empty blob means there is nothing
+        for the client to reopen: advertising it anyway makes the client parse
+        an empty buffer as a bracket, which is the crash reported when
+        continuing a tournament after leaving FUT.
         """
+        if not str(tournament_data or "").strip():
+            return False
         if int(round_value) > 1:
             return True
         raw = str(progress_data or "").strip()

--- a/tests/test_tournament_resume.py
+++ b/tests/test_tournament_resume.py
@@ -1,0 +1,145 @@
+"""Offline tournament resume invariants.
+
+Regression coverage for issue #25 (and the second half of issue #9): after
+winning a round and leaving FUT, reopening the cup crashed the client.
+
+The server advances the knockout round itself and deliberately does not invent
+a ``tournamentData`` bracket blob, so a server-advanced round has an empty one.
+It was still advertised as resumable, which handed the retail client an empty
+buffer to parse as a bracket.
+
+These tests use a temporary database and need no FIFA 14 installation.
+"""
+from __future__ import annotations
+
+import base64
+import sys
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "server"
+if str(SERVER) not in sys.path:
+    sys.path.insert(0, str(SERVER))
+
+from beta_identity import BetaIdentityStore, OFFLINE_TOURNAMENTS  # noqa: E402
+
+TOURNAMENT_ID = int(OFFLINE_TOURNAMENTS[0]["tournamentId"])
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> BetaIdentityStore:
+    store = BetaIdentityStore(str(tmp_path / "beta.db"))
+    store.ensure_beta_starter_club()
+    return store
+
+
+def _win_a_round(store: BetaIdentityStore, tournament_id: int = TOURNAMENT_ID) -> dict:
+    with closing(store._connect()) as connection, connection:
+        persona_id = int(store._identity(connection)["persona_id"])
+        return store._settle_tournament_result_locked(
+            connection, persona_id, tournament_id, "WIN", match_id="test-match"
+        )
+
+
+def _stored_row(store: BetaIdentityStore, tournament_id: int = TOURNAMENT_ID):
+    with closing(store._connect()) as connection:
+        persona_id = int(store._identity(connection)["persona_id"])
+        return connection.execute(
+            "SELECT round_value, tournament_data, progress_data FROM beta_tournament_progress "
+            "WHERE persona_id=? AND tournament_id=?",
+            (persona_id, tournament_id),
+        ).fetchone()
+
+
+def test_server_advanced_round_is_not_advertised_without_a_bracket(
+    store: BetaIdentityStore,
+) -> None:
+    """Issue #25: winning a round must not advertise an unopenable saved cup."""
+    outcome = _win_a_round(store)
+    assert outcome["advanced"] is True
+    assert outcome["round"] == 2
+
+    row = _stored_row(store)
+    assert int(row["round_value"]) == 2
+    assert str(row["tournament_data"] or "") == "", (
+        "precondition: the server advances the round without storing a bracket"
+    )
+
+    listed = store.offline_tournament_user_list()["tournamentId"]
+    assert TOURNAMENT_ID not in listed, (
+        "a cup with no stored bracket must not be offered as resumable"
+    )
+
+    resumed = store.offline_tournament_user(TOURNAMENT_ID)
+    assert not str(resumed.get("tournamentData", "")), (
+        "the client must never be handed an empty bracket to parse"
+    )
+    assert "round" not in resumed
+
+
+def test_server_still_tracks_the_round_after_a_win(store: BetaIdentityStore) -> None:
+    """Not advertising a resume must not throw away the server-side progress."""
+    _win_a_round(store)
+    with closing(store._connect()) as connection:
+        persona_id = int(store._identity(connection)["persona_id"])
+        assert store._tournament_round_locked(connection, persona_id, TOURNAMENT_ID) == 2
+
+
+def test_client_written_bracket_is_still_resumable(store: BetaIdentityStore) -> None:
+    """Guard against over-correcting: a real saved bracket must still resume."""
+    store.update_offline_tournament_user(
+        TOURNAMENT_ID,
+        {
+            "round": 2,
+            "dataVersion": 3,
+            "tournamentData": base64.b64encode(b"real-bracket-bytes").decode("ascii"),
+            "progressDataVersion": 2,
+            "progressData": base64.b64encode(b"\x01\x02\x03\x04").decode("ascii"),
+        },
+    )
+
+    assert TOURNAMENT_ID in store.offline_tournament_user_list()["tournamentId"]
+
+    resumed = store.offline_tournament_user(TOURNAMENT_ID)
+    assert int(resumed["round"]) == 2
+    assert base64.b64decode(resumed["tournamentData"]) == b"real-bracket-bytes"
+
+
+def test_first_round_pre_match_blob_is_still_rejected(store: BetaIdentityStore) -> None:
+    """Existing BETA 2.18 behaviour: zeroed first-round progress is not a save."""
+    store.update_offline_tournament_user(
+        TOURNAMENT_ID,
+        {
+            "round": 1,
+            "dataVersion": 1,
+            "tournamentData": base64.b64encode(b"pre-match-bracket").decode("ascii"),
+            "progressDataVersion": 1,
+            "progressData": base64.b64encode(b"\x00\x00\x00\x00").decode("ascii"),
+        },
+    )
+    assert TOURNAMENT_ID not in store.offline_tournament_user_list()["tournamentId"]
+
+
+@pytest.mark.parametrize(
+    "round_value, tournament_data, progress_data, expected",
+    [
+        (2, "", "", False),                                    # server-advanced round
+        (5, "", "", False),                                    # later server-advanced round
+        (1, "", "", False),                                    # untouched cup
+        (2, "YnJhY2tldA==", "", True),                         # real saved later round
+        (1, "YnJhY2tldA==", "AAAAAA==", False),                # zeroed first-round progress
+        (1, "YnJhY2tldA==", "AQIDBA==", True),                 # live first-round progress
+    ],
+)
+def test_resumable_predicate(
+    round_value: int, tournament_data: str, progress_data: str, expected: bool
+) -> None:
+    assert (
+        BetaIdentityStore._tournament_progress_is_resumable(
+            round_value, tournament_data, progress_data
+        )
+        is expected
+    )


### PR DESCRIPTION
## What changed?

Fixes #25, and the crash half of #9 ("when I tried to play the second match of the tournament, the game crashed").

**Root cause.** When a FUT match settles, `_settle_tournament_result_locked` advances the knockout round itself and deliberately writes an **empty** `tournament_data`, because the retail first-round bracket blob is known to be unsafe to persist:

```sql
VALUES (?,?,?,1,'',1,'',?)   -- round_value=2, tournament_data='', progress_data=''
```

But `_tournament_progress_is_resumable` returned `True` on `round_value > 1` alone. So the cup was advertised as a saved game, and `offline_tournament_user` answered with a round and an empty bracket. The retail client parses `tournamentData` as a bracket stream, so it was handed an empty buffer for a save it had just been told existed.

Reproduced against a temporary database, no game needed:

```
-- after winning round 1 --
  stored row              : round_value=2 tournament_data='' progress_data=''
  user_list               : {'tournamentId': [1]}                       <- advertised
  offline_tournament_user : {'round': 2, 'tournamentData': '', ...}     <- empty bracket
```

**The change.** One guard: an empty bracket is not resumable. The round counter is still kept server-side, so progression and rewards inside the session are untouched — the cup simply stops being offered as a save that cannot be reopened.

## The trade-off, stated plainly

With this change a won round is **no longer carried across a FUT restart**. Reopening the cup starts it fresh instead of crashing.

I think that is the right trade for now — losing a round beats a crash — but it does walk back part of the BETA 2.25.9 note about re-entering FUT not resetting a won round. The real fix is to persist a bracket the client can actually reopen, and I did not want to invent a `tournamentData` layout by guessing, which is the same reasoning the patcher already uses for unverified archives. You know that wire format far better than I do, so if you would rather keep the round advertised and solve it at the blob level, say so and I will close this.

## Testing

- [x] Python files compile successfully.
- [x] JSON data files parse successfully.
- [x] I did not add generated runtime state, certificates, secrets, or EA game files.
- [x] I documented any FIFA/runtime test I performed.

`tests/test_tournament_resume.py` adds 10 tests, ~5 s, temporary database, no FIFA 14 install needed. Against current `main`, 3 of them fail:

```
FAILED test_server_advanced_round_is_not_advertised_without_a_bracket
FAILED test_resumable_predicate[2---False]
FAILED test_resumable_predicate[5---False]
3 failed, 7 passed
```

Two of the passing tests exist specifically to catch over-correction, and they pass **both** before and after, which is the point:

- `test_client_written_bracket_is_still_resumable` — a genuine client-written round 2+ bracket still resumes.
- `test_first_round_pre_match_blob_is_still_rejected` — the BETA 2.18 zeroed first-round blob is still refused.

Note: this branch does not touch CI. The workflow step and `requirements-dev.txt` needed to actually run `tests/` are in #41. If you would rather merge this one first, tell me and I will move that plumbing here instead.

## Runtime test notes

No in-game run — I do not have a FIFA 14 install. The change is confined to the resume predicate and is covered above against a temporary database. An in-game confirmation would be welcome: enter Starter Cup, win round 1, leave FUT, return, and reopen the cup. Expected after this change is that the cup opens fresh at round 1 instead of crashing.
