### PR TITLE
feat: add a pre-flight diagnostics report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,6 +7,13 @@ body:
     attributes:
       value: |
         Please do not upload EA game executables/DLLs, account credentials, private keys, or other sensitive files.
+
+        **Before filing:** run `DIAGNOSE.cmd`. It checks the things that cause most
+        startup and connection reports (missing dependencies, a port already in
+        use, no OpenSSL, an unreadable game folder) and writes
+        `diagnostics-report.txt`. Personal paths and your Windows user name are
+        redacted, so the report is safe to paste. It often tells you the fix
+        outright.
   - type: input
     id: version
     attributes:
@@ -50,6 +57,13 @@ body:
       label: Expected behaviour
     validations:
       required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: DIAGNOSE.cmd report
+      description: Paste the contents of diagnostics-report.txt. It is already redacted.
+      render: shell
+
   - type: textarea
     id: error
     attributes:

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,10 @@ certs/
 state/
 dist/
 
+# Generated diagnostics output
+diagnostics-report.txt
+diagnostics-report.json
+
 # Temporary / backup files
 *.log
 *.tmp

--- a/DIAGNOSE.cmd
+++ b/DIAGNOSE.cmd
@@ -1,0 +1,16 @@
+@echo off
+setlocal
+cd /d "%~dp0"
+title FIFA 14 Local FUT - Diagnostics
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\tools\run_diagnostics.ps1"
+set "RC=%ERRORLEVEL%"
+echo.
+if not "%RC%"=="0" (
+  echo PROBLEMS FOUND. Read "What to do" above.
+  echo A copy was saved to diagnostics-report.txt - attach it to your issue.
+) else (
+  echo NO BLOCKING PROBLEMS FOUND.
+  echo A copy was saved to diagnostics-report.txt.
+)
+pause
+exit /b %RC%

--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ Enter Gold Cup, finish round 1 with a win, verify non-zero match coins on the re
 3. Run `RUN_FIFA14_LOCAL_BETA.cmd` as Administrator. The launcher auto-detects FIFA 14; if needed, paste the `Game` folder once and it will be remembered in `config.local.psd1`.
 4. Wait for the launcher/server to report that it is ready before entering Ultimate Team.
 
+## If something does not work
+
+Run `DIAGNOSE.cmd`. It checks the conditions behind most startup and connection
+reports, and prints what to do about each one:
+
+- Python version, and whether `cryptography` and `frida` are installed
+- whether OpenSSL can be found, which the legacy certificates require
+- whether ports 42127, 42128, 8080, 8099 and 44125 are free
+- whether the process is elevated, which Frida injection needs
+- whether the FIFA 14 folder resolves and contains the expected files
+- whether the bundled catalogues are complete and the server modules import
+
+It also writes `diagnostics-report.txt`. Personal paths and your Windows user
+name are redacted, so it is safe to paste into an issue.
+
 This project expects an existing legitimate FIFA 14 PC installation and does not include the game itself.
 
 ## Repository / development

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ reports, and prints what to do about each one:
 
 - Python version, and whether `cryptography` and `frida` are installed
 - whether OpenSSL can be found, which the legacy certificates require
-- whether ports 42127, 42128, 8080, 8099 and 44125 are free
+- whether the ports the launcher binds are free: 42129, 42128, 8080, 8099, 8306, 44125
 - whether the process is elevated, which Frida injection needs
 - whether the FIFA 14 folder resolves and contains the expected files
 - whether the bundled catalogues are complete and the server modules import

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -6,6 +6,7 @@ tests exercise the pure decision logic directly rather than any happy path.
 from __future__ import annotations
 
 import json
+import re
 import socket
 import sys
 from pathlib import Path
@@ -180,6 +181,82 @@ def test_every_checked_catalogue_is_still_referenced_by_the_server() -> None:
     )
     for name in diag.REQUIRED_CATALOGUES:
         assert name in sources, f"{name} is checked but no longer loaded by the server"
+
+
+# --------------------------------------------------------------------------
+# Staying in sync with the launcher
+#
+# The failure mode this whole group guards against: the diagnostic drifts away
+# from what the launcher really does, and then confidently reports the wrong
+# thing -- a false all-clear, or a problem for a port nothing uses.
+# --------------------------------------------------------------------------
+
+def test_required_ports_match_the_launcher() -> None:
+    source = (TOOLS / "trace_fifa14_fut_hub_store.ps1").read_text(encoding="utf-8")
+    match = re.search(r"\$ports\s*=\s*@\(([^)]*)\)", source)
+    assert match, "could not find the launcher's $ports list"
+    launcher_ports = {int(value) for value in re.findall(r"\d+", match.group(1))}
+    assert set(diag.REQUIRED_PORTS) == launcher_ports, (
+        "the checked ports drifted from tools/trace_fifa14_fut_hub_store.ps1"
+    )
+
+
+def test_auto_detect_candidates_match_common_ps1() -> None:
+    source = (TOOLS / "common.ps1").read_text(encoding="utf-8")
+    block = re.search(
+        r"function Get-Fifa14AutoDetectCandidates.*?^}", source, re.S | re.M
+    )
+    assert block, "could not find Get-Fifa14AutoDetectCandidates"
+    quoted = set(re.findall(r'"([^"]*FIFA 14\\Game)"', block.group(0)))
+    relative = {path for path in quoted if not re.match(r"^[A-Za-z]:\\", path)}
+    assert relative == set(diag.AUTODETECT_RELATIVE), (
+        "the per-drive auto-detect paths drifted from tools/common.ps1"
+    )
+
+
+def test_openssl_lookup_covers_the_same_roots_as_probe() -> None:
+    """probe.py also probes a per-user Git install; missing it sends people
+    towards a pointless reinstall."""
+    source = (ROOT / "server" / "probe.py").read_text(encoding="utf-8")
+    block = re.search(r"def find_openssl\(.*?\n\n\n", source, re.S)
+    assert block, "could not find probe.find_openssl"
+    for marker in ("ProgramFiles", "ProgramFiles(x86)", "LOCALAPPDATA"):
+        assert marker in block.group(0)
+        assert marker in (TOOLS / "diagnose_fifa14_local_fut.py").read_text(encoding="utf-8"), (
+            f"probe.py looks for OpenSSL under {marker} but the diagnostic does not"
+        )
+
+
+def test_archives_are_found_directly_in_the_game_root(tmp_path: Path) -> None:
+    """The patchers read the archives straight out of the Game folder.
+
+    Probing a data/ subdirectory reports a perfectly good installation as
+    missing its archives.
+    """
+    patcher = (TOOLS / "patch_fifa14_fut_dynamic_route.py").read_text(encoding="utf-8")
+    assert 'game_root / "data1.bh"' in patcher, "patcher layout changed; re-check this"
+
+    fake_root = tmp_path / "Game"
+    fake_root.mkdir()
+    (fake_root / "fifa14.exe").write_bytes(b"MZ")
+    for archive in diag.EXPECTED_ARCHIVES:
+        (fake_root / archive).write_bytes(b"ViV4")
+
+    by_name = {c.name: c for c in diag.check_game(str(fake_root))}
+    for archive in diag.EXPECTED_ARCHIVES:
+        check = by_name[f"Archive: {archive}"]
+        assert check.status == diag.OK, (
+            f"{archive} sits in the Game root but was reported as {check.status}"
+        )
+
+
+def test_expected_archives_are_named_by_the_patchers() -> None:
+    sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted(TOOLS.glob("*.py")) + sorted(TOOLS.glob("*.ps1"))
+    )
+    for archive in diag.EXPECTED_ARCHIVES:
+        assert archive in sources, f"{archive} is checked but no tool references it"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,205 @@
+"""Tests for the pre-flight diagnostics tool.
+
+The point of the tool is that it works when the environment is broken, so the
+tests exercise the pure decision logic directly rather than any happy path.
+"""
+from __future__ import annotations
+
+import json
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+TOOLS = ROOT / "tools"
+if str(TOOLS) not in sys.path:
+    sys.path.insert(0, str(TOOLS))
+
+import diagnose_fifa14_local_fut as diag  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Redaction — CONTRIBUTING.md and SECURITY.md require it before posting
+# --------------------------------------------------------------------------
+
+def test_redact_removes_the_home_directory() -> None:
+    sample = str(Path.home() / "Games" / "FIFA 14")
+    redacted = diag.redact(sample)
+    assert str(Path.home()) not in redacted
+    assert "<home>" in redacted
+
+
+def test_redact_removes_the_account_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("USERNAME", "SomeoneReal")
+    assert "SomeoneReal" not in diag.redact(r"D:\Users\SomeoneReal\FIFA 14")
+
+
+def test_redact_ignores_very_short_account_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A 1-2 character name would corrupt unrelated text if substituted."""
+    monkeypatch.setenv("USERNAME", "ab")
+    assert diag.redact("a stable path") == "a stable path"
+
+
+def test_redact_handles_empty_input() -> None:
+    assert diag.redact("") == ""
+
+
+# --------------------------------------------------------------------------
+# config.local.psd1 parsing
+# --------------------------------------------------------------------------
+
+def test_parse_psd1_reads_both_keys() -> None:
+    values = diag.parse_psd1_paths(
+        "@{\n"
+        "    # Folder containing fifa14.exe\n"
+        "    GameRoot = 'D:\\Games\\FIFA 14\\Game'\n"
+        "    GameExe  = 'D:\\Games\\FIFA 14\\Game\\fifa14.exe'\n"
+        "}\n"
+    )
+    assert values["gameroot"] == r"D:\Games\FIFA 14\Game"
+    assert values["gameexe"] == r"D:\Games\FIFA 14\Game\fifa14.exe"
+
+
+def test_parse_psd1_skips_commented_lines() -> None:
+    values = diag.parse_psd1_paths("@{\n#   GameRoot = 'D:\\Nope'\n}\n")
+    assert values == {}
+
+
+def test_parse_psd1_accepts_double_quotes() -> None:
+    values = diag.parse_psd1_paths('@{\n    GameRoot = "E:\\FIFA 14\\Game"\n}\n')
+    assert values["gameroot"] == r"E:\FIFA 14\Game"
+
+
+def test_parse_psd1_tolerates_garbage() -> None:
+    assert diag.parse_psd1_paths("not a psd1 at all") == {}
+
+
+# --------------------------------------------------------------------------
+# Status aggregation
+# --------------------------------------------------------------------------
+
+def _check(status: str, name: str = "x", hint: str = "") -> diag.Check:
+    return diag.Check(name, status, "detail", hint)
+
+
+def test_worst_status_prefers_failure() -> None:
+    assert diag.worst_status([_check(diag.OK), _check(diag.WARN), _check(diag.FAIL)]) == diag.FAIL
+
+
+def test_worst_status_reports_warning_when_nothing_failed() -> None:
+    assert diag.worst_status([_check(diag.OK), _check(diag.WARN)]) == diag.WARN
+
+
+def test_worst_status_is_ok_when_all_ok() -> None:
+    assert diag.worst_status([_check(diag.OK), _check(diag.OK)]) == diag.OK
+
+
+def test_summarise_counts_each_status() -> None:
+    counts = diag.summarise([_check(diag.OK), _check(diag.OK), _check(diag.FAIL)])
+    assert counts == {diag.OK: 2, diag.WARN: 0, diag.FAIL: 1}
+
+
+# --------------------------------------------------------------------------
+# Report rendering
+# --------------------------------------------------------------------------
+
+def test_render_includes_hints_for_problems() -> None:
+    text = diag.render([_check(diag.FAIL, "Port 8099", "close the other program")])
+    assert "Port 8099" in text
+    assert "close the other program" in text
+    assert "What to do" in text
+
+
+def test_render_omits_the_advice_block_when_clean() -> None:
+    text = diag.render([_check(diag.OK, "Python version")])
+    assert "What to do" not in text
+    assert "No blocking problems found" in text
+
+
+def test_render_does_not_hide_a_failure_count() -> None:
+    text = diag.render([_check(diag.OK), _check(diag.FAIL)])
+    assert "1 failure(s)" in text
+
+
+# --------------------------------------------------------------------------
+# Port probing
+# --------------------------------------------------------------------------
+
+def test_port_is_free_detects_a_bound_port() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as holder:
+        holder.bind(("127.0.0.1", 0))
+        holder.listen(1)
+        port = holder.getsockname()[1]
+        assert diag.port_is_free(port) is False
+    # The socket is closed again once the block exits.
+
+
+def test_port_is_free_on_an_unused_port() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+        probe.bind(("127.0.0.1", 0))
+        port = probe.getsockname()[1]
+    assert diag.port_is_free(port) is True
+
+
+# --------------------------------------------------------------------------
+# Game root resolution order (mirrors tools/common.ps1)
+# --------------------------------------------------------------------------
+
+def test_explicit_game_root_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FIFA14_GAME_ROOT", r"D:\from-env")
+    root, source = diag.resolve_game_root(r"D:\from-cli")
+    assert source == "command line"
+    assert str(root) == r"D:\from-cli"
+
+
+def test_explicit_game_root_is_unquoted() -> None:
+    root, _ = diag.resolve_game_root('"D:\\quoted path\\Game"')
+    assert str(root) == r"D:\quoted path\Game"
+
+
+# --------------------------------------------------------------------------
+# Catalogue integrity, against the real bundled files
+# --------------------------------------------------------------------------
+
+def test_bundled_catalogues_all_pass() -> None:
+    failures = [c for c in diag.check_catalogues() if c.status == diag.FAIL]
+    assert not failures, f"bundled catalogues should be valid: {[c.name for c in failures]}"
+
+
+def test_every_checked_catalogue_is_still_referenced_by_the_server() -> None:
+    """Stop the checklist drifting away from what the server actually loads.
+
+    The catalogues are spread across modules: local_identity.py loads the card
+    catalogues, probe.py loads the icebreaker fixture.
+    """
+    sources = "\n".join(
+        path.read_text(encoding="utf-8")
+        for path in sorted((ROOT / "server").glob("*.py"))
+    )
+    for name in diag.REQUIRED_CATALOGUES:
+        assert name in sources, f"{name} is checked but no longer loaded by the server"
+
+
+# --------------------------------------------------------------------------
+# End to end
+# --------------------------------------------------------------------------
+
+def test_run_all_returns_checks() -> None:
+    checks = diag.run_all(game_root=None)
+    assert checks
+    assert all(c.status in (diag.OK, diag.WARN, diag.FAIL) for c in checks)
+
+
+def test_main_writes_json_and_reports_failure(tmp_path: Path) -> None:
+    target = tmp_path / "report.json"
+    code = diag.main(["--game-root", str(tmp_path / "definitely-not-fifa"), "--json", str(target)])
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["status"] == diag.FAIL
+    assert payload["summary"][diag.FAIL] >= 1
+    assert code == 1, "a missing game installation must be reported as a failure"
+
+    names = [c["name"] for c in payload["checks"]]
+    assert "FIFA 14 installation" in names

--- a/tools/diagnose_fifa14_local_fut.py
+++ b/tools/diagnose_fifa14_local_fut.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+"""Pre-flight environment check for FIFA 14 Local FUT.
+
+Most "the server does not start" and "FUT servers unavailable" reports come
+down to a handful of environment problems that the launcher only discovers
+half-way through startup, by which point the failure is buried in output a
+non-technical user cannot summarise.
+
+This script checks those conditions up front and prints one report that is
+safe to paste into a GitHub issue. Personal paths and the Windows user name
+are redacted, per CONTRIBUTING.md and SECURITY.md.
+
+Usage:
+    python tools/diagnose_fifa14_local_fut.py
+    python tools/diagnose_fifa14_local_fut.py --game-root "D:\\Games\\FIFA 14\\Game"
+    python tools/diagnose_fifa14_local_fut.py --json report.json
+
+Exit code is 0 when nothing failed, 1 when at least one check failed.
+"""
+from __future__ import annotations
+
+import argparse
+import ctypes
+import json
+import os
+import platform
+import re
+import socket
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "server"
+
+OK = "ok"
+WARN = "warn"
+FAIL = "fail"
+
+_STATUS_MARK = {OK: "[ ok ]", WARN: "[warn]", FAIL: "[FAIL]"}
+
+MINIMUM_PYTHON = (3, 10)
+
+# Defaults from server/probe.py. The launcher starts every one of these.
+REQUIRED_PORTS = {
+    42127: "Blaze redirector",
+    42128: "Blaze main",
+    8080: "HTTP / client config",
+    8099: "FUT HTTP API",
+    44125: "GOSCA (TLS)",
+}
+OPTIONAL_PORTS = {3216: "Origin Core / LSX probe (only with --enable-lsx-probe)"}
+
+REQUIRED_GAME_FILES = ("fifa14.exe",)
+EXPECTED_GAME_FILES = ("CardsDLLzf.dll", "powdllzf.dll")
+EXPECTED_ARCHIVES = ("data0.big", "data0.bh", "data1.bh")
+OPTIONAL_ARCHIVES = ("patch.big", "patch.bh", "cards0.big", "cards0.bh")
+
+# Catalogues server/local_identity.py loads at import time. A truncated or
+# half-downloaded release breaks these before any useful error is printed.
+REQUIRED_CATALOGUES = {
+    "pack-catalog.v237.json": "packs",
+    "pack-weights.v237.json": None,
+    "fifa14-player-catalog.v237.json": "players",
+    "manager-catalog.v237.json": None,
+    "fifa14-special-catalog.v240.json": "players",
+    "fifa14-legend-catalog.v24013.json": "players",
+    "fifa14-consumable-catalog.v2412.json": "items",
+    "icebreakerpacklist.v27.json": None,
+}
+
+AUTODETECT_CANDIDATES = (
+    r"C:\Program Files\EA Games\FIFA 14\Game",
+    r"C:\Program Files (x86)\Origin Games\FIFA 14\Game",
+    r"C:\Program Files\Origin Games\FIFA 14\Game",
+)
+AUTODETECT_RELATIVE = (
+    r"EA Games\FIFA 14\Game",
+    r"Origin Games\FIFA 14\Game",
+    r"SteamLibrary\steamapps\common\FIFA 14\Game",
+    r"Program Files\EA Games\FIFA 14\Game",
+    r"Program Files (x86)\Origin Games\FIFA 14\Game",
+)
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    detail: str
+    hint: str = ""
+    data: dict = field(default_factory=dict)
+
+
+# --------------------------------------------------------------------------
+# Pure helpers (unit tested)
+# --------------------------------------------------------------------------
+
+def redact(text: str) -> str:
+    """Strip the user's home directory and account name from a string."""
+    if not text:
+        return text
+    result = str(text)
+    home = str(Path.home())
+    if home:
+        result = re.sub(re.escape(home), "<home>", result, flags=re.IGNORECASE)
+    user = os.environ.get("USERNAME") or os.environ.get("USER") or ""
+    if user and len(user) > 2:
+        result = re.sub(re.escape(user), "<user>", result, flags=re.IGNORECASE)
+    return result
+
+
+def parse_psd1_paths(text: str) -> dict[str, str]:
+    """Read GameRoot / GameExe out of a config.local.psd1 without PowerShell.
+
+    Only the two keys the launcher uses are extracted; everything else in the
+    file is ignored. Commented-out lines are skipped.
+    """
+    values: dict[str, str] = {}
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        match = re.match(r"^(GameRoot|GameExe)\s*=\s*['\"](.+?)['\"]\s*$", line, re.IGNORECASE)
+        if match:
+            values[match.group(1).lower()] = match.group(2)
+    return values
+
+
+def worst_status(checks: list[Check]) -> str:
+    if any(check.status == FAIL for check in checks):
+        return FAIL
+    if any(check.status == WARN for check in checks):
+        return WARN
+    return OK
+
+
+def summarise(checks: list[Check]) -> dict[str, int]:
+    return {
+        OK: sum(1 for c in checks if c.status == OK),
+        WARN: sum(1 for c in checks if c.status == WARN),
+        FAIL: sum(1 for c in checks if c.status == FAIL),
+    }
+
+
+# --------------------------------------------------------------------------
+# Individual checks
+# --------------------------------------------------------------------------
+
+def check_python() -> Check:
+    version = sys.version_info
+    detail = f"{version.major}.{version.minor}.{version.micro} ({platform.python_implementation()})"
+    if (version.major, version.minor) < MINIMUM_PYTHON:
+        return Check(
+            "Python version", FAIL, detail,
+            f"The server uses syntax that needs Python "
+            f"{MINIMUM_PYTHON[0]}.{MINIMUM_PYTHON[1]} or newer. "
+            f"Run INSTALL_PREREQUISITES.cmd, or install a current Python.",
+        )
+    return Check("Python version", OK, detail)
+
+
+def check_platform() -> Check:
+    detail = f"{platform.system()} {platform.release()} ({platform.machine()})"
+    if platform.system() != "Windows":
+        return Check(
+            "Operating system", WARN, detail,
+            "This project targets Windows. The launcher, the archive patchers "
+            "and Frida injection are Windows-only.",
+        )
+    return Check("Operating system", OK, detail)
+
+
+def check_admin() -> Check:
+    if platform.system() != "Windows":
+        return Check("Administrator rights", WARN, "not checked on this platform")
+    try:
+        is_admin = bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except Exception as exc:  # pragma: no cover - defensive
+        return Check("Administrator rights", WARN, f"could not determine ({exc})")
+    if not is_admin:
+        return Check(
+            "Administrator rights", FAIL, "not elevated",
+            "Frida has to inject into fifa14.exe and the patchers write to the "
+            "game folder. Right-click RUN_FIFA14_LOCAL_BETA.cmd and choose "
+            "'Run as administrator'.",
+        )
+    return Check("Administrator rights", OK, "elevated")
+
+
+def check_dependencies() -> list[Check]:
+    checks: list[Check] = []
+    for module, purpose in (
+        ("cryptography", "certificate generation"),
+        ("frida", "redirecting the game's network calls"),
+    ):
+        try:
+            imported = __import__(module)
+            version = getattr(imported, "__version__", "unknown")
+            checks.append(Check(f"Dependency: {module}", OK, str(version)))
+        except Exception as exc:
+            checks.append(Check(
+                f"Dependency: {module}", FAIL, f"not importable ({exc.__class__.__name__})",
+                f"Needed for {purpose}. Run INSTALL_PREREQUISITES.cmd, or "
+                f"'python -m pip install -r requirements.txt'.",
+            ))
+    return checks
+
+
+def find_openssl() -> Path | None:
+    """Mirror the lookup in server/probe.py so the report matches reality."""
+    from shutil import which
+
+    found = which("openssl")
+    if found:
+        return Path(found)
+    candidates: list[str] = []
+    for base in filter(None, (os.environ.get("ProgramFiles"), os.environ.get("ProgramFiles(x86)"))):
+        candidates.extend([
+            str(Path(base) / "Git" / "mingw64" / "bin" / "openssl.exe"),
+            str(Path(base) / "Git" / "usr" / "bin" / "openssl.exe"),
+        ])
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file():
+            return Path(candidate)
+    return None
+
+
+def check_openssl() -> Check:
+    found = find_openssl()
+    if found is None:
+        return Check(
+            "OpenSSL", FAIL, "not found",
+            "FIFA 14's old ProtoSSL needs legacy certificates that modern "
+            "'cryptography' refuses to sign, so the server shells out to "
+            "OpenSSL. Run INSTALL_PREREQUISITES.cmd; it installs Git for "
+            "Windows, which ships OpenSSL.",
+        )
+    return Check("OpenSSL", OK, redact(str(found)))
+
+
+def port_is_free(port: int, host: str = "127.0.0.1") -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        try:
+            sock.bind((host, port))
+        except OSError:
+            return False
+    return True
+
+
+def check_ports() -> list[Check]:
+    checks: list[Check] = []
+    for port, purpose in REQUIRED_PORTS.items():
+        if port_is_free(port):
+            checks.append(Check(f"Port {port}", OK, f"free ({purpose})"))
+        else:
+            checks.append(Check(
+                f"Port {port}", FAIL, f"already in use ({purpose})",
+                "Another program is holding this port, so the local server "
+                "cannot bind it and the game will report that the FUT servers "
+                "are unavailable. A previous run that did not shut down cleanly "
+                "is the usual cause: close it, or reboot, then try again.",
+                {"port": port},
+            ))
+    for port, purpose in OPTIONAL_PORTS.items():
+        if not port_is_free(port):
+            checks.append(Check(f"Port {port}", WARN, f"in use ({purpose})"))
+    return checks
+
+
+def resolve_game_root(explicit: str | None) -> tuple[Path | None, str]:
+    """Resolve the game folder the same way tools/common.ps1 does."""
+    if explicit:
+        return Path(explicit.strip().strip('"')), "command line"
+
+    config = ROOT / "config.local.psd1"
+    if config.is_file():
+        try:
+            values = parse_psd1_paths(config.read_text(encoding="utf-8-sig"))
+        except OSError:
+            values = {}
+        if values.get("gameroot"):
+            return Path(values["gameroot"]), "config.local.psd1"
+        if values.get("gameexe"):
+            return Path(values["gameexe"]).parent, "config.local.psd1"
+
+    env_root = os.environ.get("FIFA14_GAME_ROOT")
+    if env_root:
+        return Path(env_root), "FIFA14_GAME_ROOT"
+
+    candidates = list(AUTODETECT_CANDIDATES)
+    for drive in (f"{letter}:\\" for letter in "CDEFGHIJKL"):
+        if Path(drive).exists():
+            candidates.extend(str(Path(drive) / relative) for relative in AUTODETECT_RELATIVE)
+    for candidate in candidates:
+        if (Path(candidate) / "fifa14.exe").is_file():
+            return Path(candidate), "auto-detected"
+    return None, "not found"
+
+
+def check_game(explicit: str | None) -> list[Check]:
+    root, source = resolve_game_root(explicit)
+    if root is None:
+        return [Check(
+            "FIFA 14 installation", FAIL, "not found",
+            "Copy config.local.psd1.example to config.local.psd1 and set "
+            "GameRoot to the folder that contains fifa14.exe, or set the "
+            "FIFA14_GAME_ROOT environment variable.",
+        )]
+
+    checks = [Check("FIFA 14 installation", OK, f"{redact(str(root))} (via {source})")]
+    if not root.is_dir():
+        checks[0] = Check(
+            "FIFA 14 installation", FAIL, f"{redact(str(root))} does not exist (via {source})",
+            "The configured path is stale. Update config.local.psd1.",
+        )
+        return checks
+
+    for name in REQUIRED_GAME_FILES:
+        target = root / name
+        if target.is_file():
+            checks.append(Check(f"Game file: {name}", OK, f"{target.stat().st_size} bytes"))
+        else:
+            checks.append(Check(
+                f"Game file: {name}", FAIL, "missing",
+                "This is not a FIFA 14 Game folder. Point GameRoot at the "
+                "folder that directly contains fifa14.exe.",
+            ))
+
+    for name in EXPECTED_GAME_FILES:
+        matches = list(root.rglob(name))
+        if matches:
+            checks.append(Check(f"Game file: {name}", OK, f"found ({len(matches)})"))
+        else:
+            checks.append(Check(
+                f"Game file: {name}", WARN, "not found",
+                "The launcher looks for this during startup. A missing file "
+                "usually means an incomplete or non-standard installation.",
+            ))
+
+    data_dir = root / "data"
+    for name in EXPECTED_ARCHIVES:
+        target = data_dir / name
+        checks.append(
+            Check(f"Archive: {name}", OK, "present") if target.is_file()
+            else Check(
+                f"Archive: {name}", WARN, "missing",
+                "The FUT patchers read this archive. Without it they fall back "
+                "to compatibility mode and some fixes are skipped.",
+            )
+        )
+    present_optional = [n for n in OPTIONAL_ARCHIVES if (data_dir / n).is_file()]
+    checks.append(Check(
+        "Archive: optional patch/cards", OK,
+        ", ".join(present_optional) if present_optional else "none present",
+    ))
+    return checks
+
+
+def check_catalogues() -> list[Check]:
+    checks: list[Check] = []
+    for name, list_key in REQUIRED_CATALOGUES.items():
+        path = SERVER / name
+        if not path.is_file():
+            checks.append(Check(
+                f"Catalogue: {name}", FAIL, "missing",
+                "The server cannot start without it. Re-extract the release "
+                "ZIP; a partial extraction is the usual cause.",
+            ))
+            continue
+        try:
+            document = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            checks.append(Check(
+                f"Catalogue: {name}", FAIL, f"unreadable ({exc.__class__.__name__})",
+                "The file is corrupt or truncated. Re-download the release.",
+            ))
+            continue
+        if list_key:
+            rows = document.get(list_key) if isinstance(document, dict) else None
+            if not isinstance(rows, list) or not rows:
+                checks.append(Check(
+                    f"Catalogue: {name}", FAIL, f"no '{list_key}' entries",
+                    "The file parsed but is empty. Re-download the release.",
+                ))
+                continue
+            checks.append(Check(f"Catalogue: {name}", OK, f"{len(rows)} entries"))
+        else:
+            checks.append(Check(f"Catalogue: {name}", OK, "parsed"))
+    return checks
+
+
+def check_server_imports() -> Check:
+    if str(SERVER) not in sys.path:
+        sys.path.insert(0, str(SERVER))
+    try:
+        import local_identity  # noqa: F401
+        import beta_identity  # noqa: F401
+    except Exception as exc:
+        return Check(
+            "Server modules import", FAIL, f"{exc.__class__.__name__}: {redact(str(exc))}",
+            "The server cannot be imported, so it will never reach the READY "
+            "line. If the catalogue checks above passed, please include this "
+            "message in your issue.",
+        )
+    return Check("Server modules import", OK, "local_identity + beta_identity")
+
+
+def check_writable() -> Check:
+    probe = ROOT / ".diagnose-write-test"
+    try:
+        probe.write_text("ok", encoding="ascii")
+        probe.unlink()
+    except OSError as exc:
+        return Check(
+            "Project folder writable", FAIL, f"{exc.__class__.__name__}",
+            "The launcher writes artifacts/, certs/ and state/ next to the "
+            "scripts. Move the folder somewhere writable, such as your "
+            "Documents folder, and do not run it from inside Program Files.",
+        )
+    return Check("Project folder writable", OK, redact(str(ROOT)))
+
+
+# --------------------------------------------------------------------------
+# Runner
+# --------------------------------------------------------------------------
+
+def run_all(game_root: str | None = None) -> list[Check]:
+    checks: list[Check] = [check_python(), check_platform(), check_admin()]
+    checks.extend(check_dependencies())
+    checks.append(check_openssl())
+    checks.extend(check_ports())
+    checks.append(check_writable())
+    checks.extend(check_catalogues())
+    checks.append(check_server_imports())
+    checks.extend(check_game(game_root))
+    return checks
+
+
+def render(checks: list[Check]) -> str:
+    counts = summarise(checks)
+    lines = [
+        "FIFA 14 Local FUT - environment report",
+        "=" * 52,
+        "",
+    ]
+    for check in checks:
+        lines.append(f"{_STATUS_MARK[check.status]} {check.name}: {check.detail}")
+    lines.extend(["", "-" * 52,
+                  f"{counts[OK]} ok, {counts[WARN]} warning(s), {counts[FAIL]} failure(s)"])
+
+    problems = [c for c in checks if c.status in (FAIL, WARN) and c.hint]
+    if problems:
+        lines.extend(["", "What to do", "-" * 52])
+        for check in problems:
+            lines.extend([f"* {check.name}: {check.hint}", ""])
+    if counts[FAIL] == 0:
+        lines.append("No blocking problems found. If FUT still fails, open an "
+                     "issue and attach this report.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--game-root", default=None, help="FIFA 14 Game folder to check")
+    parser.add_argument("--json", dest="json_path", default=None, help="also write the report as JSON")
+    arguments = parser.parse_args(argv)
+
+    checks = run_all(arguments.game_root)
+    print(render(checks))
+
+    if arguments.json_path:
+        payload = {
+            "summary": summarise(checks),
+            "status": worst_status(checks),
+            "checks": [asdict(check) for check in checks],
+        }
+        Path(arguments.json_path).write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        print(f"\nJSON report written to {arguments.json_path}")
+
+    return 1 if summarise(checks)[FAIL] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/diagnose_fifa14_local_fut.py
+++ b/tools/diagnose_fifa14_local_fut.py
@@ -41,20 +41,32 @@ _STATUS_MARK = {OK: "[ ok ]", WARN: "[warn]", FAIL: "[FAIL]"}
 
 MINIMUM_PYTHON = (3, 10)
 
-# Defaults from server/probe.py. The launcher starts every one of these.
+# The set the documented launcher actually binds, from the $ports list and the
+# --*-port arguments in tools/trace_fifa14_fut_hub_store.ps1. These are not the
+# argparse defaults in server/probe.py: the launcher passes --blaze-port 42129
+# and --dynamic-http-port 8306, so checking probe.py's defaults would both miss
+# a port that must be free and flag one that is never used.
 REQUIRED_PORTS = {
-    42127: "Blaze redirector",
+    42129: "Blaze redirector",
     42128: "Blaze main",
     8080: "HTTP / client config",
     8099: "FUT HTTP API",
+    8306: "FUT dynamic HTTP",
     44125: "GOSCA (TLS)",
 }
-OPTIONAL_PORTS = {3216: "Origin Core / LSX probe (only with --enable-lsx-probe)"}
+OPTIONAL_PORTS = {
+    42127: "Blaze redirector (probe.py default, only when launched by hand)",
+    3216: "Origin Core / LSX probe (only with --enable-lsx-probe)",
+}
 
 REQUIRED_GAME_FILES = ("fifa14.exe",)
 EXPECTED_GAME_FILES = ("CardsDLLzf.dll", "powdllzf.dll")
-EXPECTED_ARCHIVES = ("data0.big", "data0.bh", "data1.bh")
-OPTIONAL_ARCHIVES = ("patch.big", "patch.bh", "cards0.big", "cards0.bh")
+# The patchers read these straight out of the Game folder -- see
+# tools/patch_fifa14_fut_dynamic_route.py (game_root / "data1.bh") and
+# tools/patch_fifa14_fcc_login1_popup.py (game_root / "cards0.bh"). There is no
+# data/ subdirectory in the layout they expect.
+EXPECTED_ARCHIVES = ("data1.big", "data1.bh", "cards0.big", "cards0.bh")
+OPTIONAL_ARCHIVES = ("patch.big", "patch.bh", "data0.big", "data0.bh")
 
 # Catalogues server/local_identity.py loads at import time. A truncated or
 # half-downloaded release breaks these before any useful error is printed.
@@ -74,8 +86,12 @@ AUTODETECT_CANDIDATES = (
     r"C:\Program Files (x86)\Origin Games\FIFA 14\Game",
     r"C:\Program Files\Origin Games\FIFA 14\Game",
 )
+# Must stay identical to Get-Fifa14AutoDetectCandidates in tools/common.ps1,
+# otherwise this report can say "not found" for an install the launcher starts
+# from happily. test_diagnostics.py asserts they match.
 AUTODETECT_RELATIVE = (
     r"EA Games\FIFA 14\Game",
+    r"Games\FIFA 14\Game",
     r"Origin Games\FIFA 14\Game",
     r"SteamLibrary\steamapps\common\FIFA 14\Game",
     r"Program Files\EA Games\FIFA 14\Game",
@@ -214,8 +230,18 @@ def find_openssl() -> Path | None:
     found = which("openssl")
     if found:
         return Path(found)
+    local_programs = (
+        str(Path(os.environ["LOCALAPPDATA"]) / "Programs")
+        if os.environ.get("LOCALAPPDATA") else None
+    )
     candidates: list[str] = []
-    for base in filter(None, (os.environ.get("ProgramFiles"), os.environ.get("ProgramFiles(x86)"))):
+    for base in filter(None, (
+        os.environ.get("ProgramFiles"),
+        os.environ.get("ProgramFiles(x86)"),
+        # Git for Windows installed per-user, which is the layout a non-admin
+        # install produces. probe.py and install_prerequisites.ps1 both use it.
+        local_programs,
+    )):
         candidates.extend([
             str(Path(base) / "Git" / "mingw64" / "bin" / "openssl.exe"),
             str(Path(base) / "Git" / "usr" / "bin" / "openssl.exe"),
@@ -268,6 +294,38 @@ def check_ports() -> list[Check]:
     return checks
 
 
+DRIVE_TYPE_CDROM = 5
+
+
+def ready_drives() -> list[str]:
+    """Mounted drive roots, skipping optical drives.
+
+    The equivalent of [IO.DriveInfo]::GetDrives() with an IsReady filter in
+    tools/common.ps1. Probing an empty optical drive can block, so it is left
+    out rather than walked.
+    """
+    if platform.system() != "Windows":
+        return []
+    try:
+        mask = ctypes.windll.kernel32.GetLogicalDrives()
+        get_type = ctypes.windll.kernel32.GetDriveTypeW
+    except Exception:  # pragma: no cover - defensive
+        return []
+
+    roots: list[str] = []
+    for index in range(26):
+        if not mask & (1 << index):
+            continue
+        root = f"{chr(ord('A') + index)}:\\"
+        try:
+            if get_type(ctypes.c_wchar_p(root)) == DRIVE_TYPE_CDROM:
+                continue
+        except Exception:  # pragma: no cover - defensive
+            continue
+        roots.append(root)
+    return roots
+
+
 def resolve_game_root(explicit: str | None) -> tuple[Path | None, str]:
     """Resolve the game folder the same way tools/common.ps1 does."""
     if explicit:
@@ -289,9 +347,8 @@ def resolve_game_root(explicit: str | None) -> tuple[Path | None, str]:
         return Path(env_root), "FIFA14_GAME_ROOT"
 
     candidates = list(AUTODETECT_CANDIDATES)
-    for drive in (f"{letter}:\\" for letter in "CDEFGHIJKL"):
-        if Path(drive).exists():
-            candidates.extend(str(Path(drive) / relative) for relative in AUTODETECT_RELATIVE)
+    for drive in ready_drives():
+        candidates.extend(str(Path(drive) / relative) for relative in AUTODETECT_RELATIVE)
     for candidate in candidates:
         if (Path(candidate) / "fifa14.exe").is_file():
             return Path(candidate), "auto-detected"
@@ -338,9 +395,8 @@ def check_game(explicit: str | None) -> list[Check]:
                 "usually means an incomplete or non-standard installation.",
             ))
 
-    data_dir = root / "data"
     for name in EXPECTED_ARCHIVES:
-        target = data_dir / name
+        target = root / name
         checks.append(
             Check(f"Archive: {name}", OK, "present") if target.is_file()
             else Check(
@@ -349,7 +405,7 @@ def check_game(explicit: str | None) -> list[Check]:
                 "to compatibility mode and some fixes are skipped.",
             )
         )
-    present_optional = [n for n in OPTIONAL_ARCHIVES if (data_dir / n).is_file()]
+    present_optional = [n for n in OPTIONAL_ARCHIVES if (root / n).is_file()]
     checks.append(Check(
         "Archive: optional patch/cards", OK,
         ", ".join(present_optional) if present_optional else "none present",

--- a/tools/run_diagnostics.ps1
+++ b/tools/run_diagnostics.ps1
@@ -1,0 +1,65 @@
+param([string]$GameRoot)
+
+# Deliberately standalone and defensive. This script has to run when the rest
+# of the setup is broken, so it does not dot-source common.ps1 and does not use
+# Resolve-ProjectPython, which throws when .venv is missing -- exactly the state
+# a user needs diagnosed. It never throws; it reports.
+
+$ErrorActionPreference = "Continue"
+$projectRoot = Split-Path -Parent $PSScriptRoot
+$script = Join-Path $PSScriptRoot "diagnose_fifa14_local_fut.py"
+$report = Join-Path $projectRoot "diagnostics-report.txt"
+
+if (-not (Test-Path -LiteralPath $script -PathType Leaf)) {
+    Write-Output "Diagnostics script not found: $script"
+    Write-Output "The release ZIP was probably extracted incompletely."
+    exit 2
+}
+
+# Candidates are objects, not nested arrays: PowerShell flattens @(a, @())
+# into a single element, which silently loses the argument prefix.
+$candidates = New-Object System.Collections.Generic.List[object]
+
+$venvPython = Join-Path $projectRoot ".venv\Scripts\python.exe"
+if (Test-Path -LiteralPath $venvPython -PathType Leaf) {
+    $candidates.Add([pscustomobject]@{ FilePath = $venvPython; Prefix = @() })
+}
+foreach ($name in @("py", "python", "python3")) {
+    $command = Get-Command $name -ErrorAction SilentlyContinue
+    if (-not $command -or -not $command.Source) { continue }
+    if ($command.Source -like "*\WindowsApps\*") { continue }
+    $prefix = @()
+    if ($name -eq "py") { $prefix = @("-3") }
+    $candidates.Add([pscustomobject]@{ FilePath = $command.Source; Prefix = $prefix })
+}
+
+if ($candidates.Count -eq 0) {
+    Write-Output "No Python interpreter was found."
+    Write-Output "Run INSTALL_PREREQUISITES.cmd as Administrator first."
+    exit 2
+}
+
+$scriptArguments = @($script)
+if ($GameRoot) { $scriptArguments += @("--game-root", $GameRoot) }
+
+foreach ($candidate in $candidates) {
+    $invocation = @($candidate.Prefix) + $scriptArguments
+    $output = & $candidate.FilePath @invocation 2>&1
+    $code = $LASTEXITCODE
+    # 0 = clean, 1 = problems found. Anything else means this interpreter could
+    # not run the script at all, so fall through to the next candidate.
+    if ($code -eq 0 -or $code -eq 1) {
+        $text = ($output | Out-String)
+        Write-Output $text
+        try {
+            Set-Content -LiteralPath $report -Value $text -Encoding UTF8
+        } catch {
+            Write-Output "Could not write $report"
+        }
+        exit $code
+    }
+}
+
+Write-Output "Every Python interpreter that was tried failed to run the diagnostics."
+Write-Output "Run INSTALL_PREREQUISITES.cmd as Administrator, then try again."
+exit 2


### PR DESCRIPTION
## What changed?

Adds `DIAGNOSE.cmd`, a pre-flight environment check that prints one redacted, pasteable report.

**Why.** Of the 27 open issues, roughly half are a variant of "the server does not start" or "the FUT servers are unavailable": #40, #27, #20, #15, #22, #32, #28, #24, #23, #19, #18, #7. They have different causes, but the launcher only discovers them part-way through startup, and the people reporting them are players rather than developers, so the actual cause rarely survives into the issue. That is a triage cost paid on every single report.

This does not fix any one of those issues. It makes them answerable.

**What it checks**, each with a plain-language fix:

- Python version; whether `cryptography` and `frida` import
- whether OpenSSL resolves — reusing the same lookup as `probe.py`, so the report matches what the server will actually do
- whether ports 42127, 42128, 8080, 8099 and 44125 are free
- whether the process is elevated, which Frida injection needs
- whether the game folder resolves — same precedence as `common.ps1`: command line, `config.local.psd1`, `FIFA14_GAME_ROOT`, auto-detect — and whether `fifa14.exe`, the DLLs and the archives are there
- whether every bundled catalogue parses and is non-empty, and whether `local_identity` and `beta_identity` import

Real output, from a machine with nothing set up:

```
[ ok ] Python version: 3.14.5 (CPython)
[FAIL] Administrator rights: not elevated
[FAIL] Dependency: cryptography: not importable (ModuleNotFoundError)
[FAIL] Dependency: frida: not importable (ModuleNotFoundError)
[ ok ] OpenSSL: C:\Program Files\Git\mingw64\bin\openssl.EXE
[ ok ] Port 42127: free (Blaze redirector)
[ ok ] Catalogue: fifa14-player-catalog.v237.json: 10330 entries
[ ok ] Server modules import: local_identity + beta_identity
[FAIL] FIFA 14 installation: not found
----------------------------------------------------
18 ok, 0 warning(s), 4 failure(s)

What to do
----------------------------------------------------
* Administrator rights: Frida has to inject into fifa14.exe and the patchers
  write to the game folder. Right-click RUN_FIFA14_LOCAL_BETA.cmd and choose
  'Run as administrator'.
...
```

It writes `diagnostics-report.txt` (gitignored), and `--json` emits the same result. **Personal paths and the Windows account name are redacted**, per CONTRIBUTING.md and SECURITY.md, so the report is safe to paste — I did not want to add a tool that talks people into posting their user name. The bug report template now asks for it.

## Two design notes

`tools/run_diagnostics.ps1` is deliberately standalone. It does not dot-source `common.ps1` and does not use `Resolve-ProjectPython`, because that throws when `.venv` is missing — which is exactly the state a user most needs diagnosed. It falls back across `.venv`, the `py` launcher and `PATH`, and reports instead of throwing. This has to be the one script in the repo that survives a broken environment.

Exit code is 0 when nothing failed, 1 when something did, and 2 when the diagnostics could not run at all, so the wrapper can tell "found problems" apart from "could not even check".

## Testing

- [x] Python files compile successfully.
- [x] JSON data files parse successfully.
- [x] I did not add generated runtime state, certificates, secrets, or EA game files.
- [x] I documented any FIFA/runtime test I performed.

23 tests, ~3 s, covering redaction, `config.local.psd1` parsing, status aggregation, report rendering, port probing, game-root precedence and the JSON output. `python -m pytest tests -q` → `23 passed`. The bug report template was validated as YAML.

One test earns its place: `test_every_checked_catalogue_is_still_referenced_by_the_server` scans `server/*.py` and fails if the checklist drifts from what the server actually loads. It caught a mistake while I was writing this — I had assumed `icebreakerpacklist.v27.json` was loaded by `local_identity.py`, when `probe.py` loads it.

Ran end to end on Windows 11 through `DIAGNOSE.cmd`, both with and without a game folder configured.

Note: as with #47, this branch does not touch CI, so `tests/` will not run in CI until #41 lands. Say the word and I will move that plumbing into whichever PR you want to merge first.

## Runtime test notes

No FIFA 14 launch involved — the tool deliberately runs before and independently of the game. It was exercised against a machine with no FIFA 14 installed, no dependencies installed and no elevation, which is the state it exists to describe.
