### PR TITLE
fix: Support multiple FUT squads, fix squad deletion and unfinished-squad auto-fill

### DIFF
--- a/server/beta_identity.py
+++ b/server/beta_identity.py
@@ -1204,7 +1204,10 @@ class BetaIdentityStore(LocalIdentityStore):
             # Truly fresh BETA profile only: there is no existing club to preserve.
             connection.execute("DELETE FROM pack_contents")
             connection.execute("DELETE FROM packs WHERE persona_id=?", (persona_id,))
-            connection.execute("DELETE FROM squad_players")
+            connection.execute(
+                "DELETE FROM squad_players WHERE squad_id IN (SELECT squad_id FROM squads WHERE persona_id=?)",
+                (persona_id,),
+            )
             connection.execute("DELETE FROM squads WHERE persona_id=?", (persona_id,))
             connection.execute("DELETE FROM items WHERE persona_id=?", (persona_id,))
             connection.execute("DELETE FROM clubs WHERE persona_id=?", (persona_id,))

--- a/server/local_identity.py
+++ b/server/local_identity.py
@@ -4668,18 +4668,39 @@ class LocalIdentityStore:
         if not isinstance(document, dict):
             raise ValueError("squad body must be a JSON object")
         players = document.get("players")
+        requested_id = self._document_squad_id(document, requested_id)
         # The retail tournament handoff sends a partial captain/kicktakers PUT
         # immediately before MatchReady. It intentionally contains no players array.
         if players is None:
+            if requested_id > 0:
+                # The squad hub renames through the same players-less PUT, so
+                # apply whatever metadata it carries instead of dropping it.
+                self.update_squad_metadata(requested_id, document)
             return self.squad_list()
         if not isinstance(players, list):
             raise ValueError("squad players must be an array")
-        formation = str(document.get("formation") or "f442")
-        squad_name = str(document.get("squadName") or "Local XI").strip()[:32] or "Local XI"
-        chemistry = self._bounded_int(document.get("chemistry", 0), 0, minimum=0, maximum=100)
-        star_rating = self._bounded_int(
-            document.get("starRating", document.get("rating", 0)), 0, minimum=0, maximum=100
+        # The squad editor's closing write carries all 23 slots and the formation
+        # but no squadName.  Every metadata member is therefore optional: an
+        # absent one keeps what the squad already has rather than reverting it to
+        # the historical default, which is what silently renamed squads back to
+        # "Local XI" as soon as the user left the editor.
+        requested_name = document.get("squadName")
+        requested_name = (
+            str(requested_name).strip()[:32]
+            if isinstance(requested_name, str) and str(requested_name).strip() else None
         )
+        requested_formation = document.get("formation")
+        requested_formation = (
+            str(requested_formation).strip()
+            if isinstance(requested_formation, str) and str(requested_formation).strip() else None
+        )
+        requested_chemistry = document.get("chemistry") if "chemistry" in document else None
+        if "starRating" in document:
+            requested_rating = document.get("starRating")
+        elif "rating" in document:
+            requested_rating = document.get("rating")
+        else:
+            requested_rating = None
 
         with self._lock, closing(self._connect()) as connection, connection:
             identity = self._identity(connection)
@@ -4687,7 +4708,7 @@ class LocalIdentityStore:
             persona_id = int(identity["persona_id"])
             self._repair_owned_items_locked(connection, persona_id)
             active_id = fut_user["active_squad_id"]
-            squad_id = int(active_id) if requested_id in (None, 0) and active_id is not None else int(requested_id or 0)
+            squad_id = requested_id if requested_id > 0 else (int(active_id) if active_id is not None else 0)
             row = None
             if squad_id > 0:
                 row = connection.execute(
@@ -4695,15 +4716,47 @@ class LocalIdentityStore:
                     "WHERE persona_id = ? AND squad_id = ?", (persona_id, squad_id)
                 ).fetchone()
             if row is None:
-                cursor = connection.execute(
-                    "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating) VALUES (?, ?, ?, 1, ?, ?)",
-                    (persona_id, squad_name, formation, chemistry, star_rating),
+                insert_values = (
+                    requested_name or "Local XI",
+                    requested_formation or "f442",
+                    self._bounded_int(requested_chemistry, 0, minimum=0, maximum=100),
+                    self._bounded_int(requested_rating, 0, minimum=0, maximum=100),
                 )
-                squad_id = int(cursor.lastrowid)
+                if squad_id > 0:
+                    # A write naming an unknown squad creates it under the id the
+                    # client chose, so its follow-up GET /squad/{id} resolves.
+                    connection.execute(
+                        "INSERT INTO squads (squad_id, persona_id, squad_name, formation, active, chemistry, star_rating) "
+                        "VALUES (?, ?, ?, ?, 0, ?, ?)",
+                        (squad_id, persona_id, *insert_values),
+                    )
+                else:
+                    cursor = connection.execute(
+                        "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating) VALUES (?, ?, ?, 0, ?, ?)",
+                        (persona_id, *insert_values),
+                    )
+                    squad_id = int(cursor.lastrowid)
                 row = connection.execute(
                     "SELECT squad_id,squad_name,formation,active,chemistry,star_rating FROM squads WHERE squad_id=?",
                     (squad_id,),
                 ).fetchone()
+
+            squad_name = requested_name or str(row["squad_name"] or "Local XI")
+            formation = requested_formation or str(row["formation"] or "f442")
+            chemistry = (
+                self._bounded_int(requested_chemistry, 0, minimum=0, maximum=100)
+                if requested_chemistry is not None else int(row["chemistry"] or 0)
+            )
+            star_rating = (
+                self._bounded_int(requested_rating, 0, minimum=0, maximum=100)
+                if requested_rating is not None else int(row["star_rating"] or 0)
+            )
+
+            # Retail echoes the squad's own active flag back on save.  Only an
+            # explicit false leaves the current match squad alone; a body without
+            # the member keeps the historical select-on-save behaviour.
+            explicit_active = document.get("active")
+            should_activate = bool(explicit_active) if isinstance(explicit_active, (bool, int)) else True
 
             existing_rows = {
                 int(existing["slot_index"]): existing
@@ -4740,55 +4793,217 @@ class LocalIdentityStore:
                 # Do not let the transient GK-only/mostly-zero parser state destroy
                 # either the 23 slots or the known-good chemistry/rating/name.  Only
                 # reaffirm which existing squad is active and acknowledge the PUT.
-                connection.execute("UPDATE squads SET active = 0 WHERE persona_id = ?", (persona_id,))
-                connection.execute("UPDATE squads SET active = 1 WHERE squad_id = ?", (squad_id,))
-                connection.execute(
-                    "UPDATE fut_users SET active_squad_id = ? WHERE persona_id = ?", (squad_id, persona_id)
-                )
+                self._set_active_squad_locked(connection, persona_id, squad_id, force=should_activate)
                 connection.commit()
                 return self.squad_list()
 
-            connection.execute("UPDATE squads SET active = 0 WHERE persona_id = ?", (persona_id,))
             connection.execute(
-                "UPDATE squads SET squad_name = ?, formation = ?, active = 1, chemistry = ?, star_rating = ? WHERE squad_id = ?",
+                "UPDATE squads SET squad_name = ?, formation = ?, chemistry = ?, star_rating = ? WHERE squad_id = ?",
                 (squad_name, formation, chemistry, star_rating, squad_id),
             )
+            self._set_active_squad_locked(connection, persona_id, squad_id, force=should_activate)
             connection.execute("DELETE FROM squad_players WHERE squad_id = ?", (squad_id,))
-            used_items: set[int] = set()
             for index in range(23):
                 item = incoming.get(index)
                 kit_number = incoming_kit_numbers.get(index, 0)
                 self._write_squad_slot_locked(connection, squad_id, index, item, kit_number=kit_number)
-                if item is not None:
-                    used_items.add(int(item["item_id"]))
 
-            connection.execute(
-                "UPDATE fut_users SET active_squad_id = ? WHERE persona_id = ?", (squad_id, persona_id)
+            self._sync_player_piles_locked(connection, persona_id)
+        return self.squad_list()
+
+    def _sync_player_piles_locked(self, connection: sqlite3.Connection, persona_id: int) -> None:
+        """Mark owned players 'squad' when *any* squad fields them, 'club' otherwise.
+
+        Membership is deliberately evaluated across every squad the persona owns:
+        scoping it to the squad currently being written would demote the members
+        of all other squads back to My Club on each save.
+        """
+        squad_member_ids = {
+            int(row["item_id"])
+            for row in connection.execute(
+                "SELECT sp.item_id FROM squad_players sp JOIN squads s ON s.squad_id = sp.squad_id "
+                "WHERE s.persona_id = ? AND sp.item_id > 0",
+                (int(persona_id),),
+            ).fetchall()
+        }
+        for item_row in connection.execute(
+            "SELECT * FROM items WHERE persona_id = ? AND item_type = ? AND pile NOT IN ('trade','pending')", (persona_id, PLAYER_ITEM_TYPE)
+        ).fetchall():
+            item_id = int(item_row["item_id"])
+            if int(item_row["asset_id"]) not in PLAYER_REFERENCE_BY_ASSET:
+                continue
+            try:
+                existing_payload = json.loads(item_row["payload"] or "{}")
+            except (TypeError, json.JSONDecodeError):
+                existing_payload = {}
+            in_squad = item_id in squad_member_ids
+            payload = self._canonical_player_payload(
+                item_id=item_id, asset_id=int(item_row["asset_id"]),
+                existing=existing_payload if isinstance(existing_payload, dict) else {},
+                pile=7,
             )
-            for item_row in connection.execute(
-                "SELECT * FROM items WHERE persona_id = ? AND item_type = ? AND pile NOT IN ('trade','pending')", (persona_id, PLAYER_ITEM_TYPE)
-            ).fetchall():
-                item_id = int(item_row["item_id"])
-                if int(item_row["asset_id"]) not in PLAYER_REFERENCE_BY_ASSET:
-                    continue
-                try:
-                    existing_payload = json.loads(item_row["payload"] or "{}")
-                except (TypeError, json.JSONDecodeError):
-                    existing_payload = {}
-                in_squad = item_id in used_items
-                payload = self._canonical_player_payload(
-                    item_id=item_id, asset_id=int(item_row["asset_id"]),
-                    existing=existing_payload if isinstance(existing_payload, dict) else {},
-                    pile=7,
+            connection.execute(
+                "UPDATE items SET item_type = ?, pile = ?, payload = ? WHERE item_id = ? AND persona_id = ?",
+                (
+                    PLAYER_ITEM_TYPE, "squad" if in_squad else "club",
+                    json.dumps(payload, separators=(",", ":"), ensure_ascii=False),
+                    item_id, persona_id,
+                ),
+            )
+
+    @staticmethod
+    def _document_squad_id(document: dict[str, Any], requested_id: int | None) -> int:
+        """Resolve which squad a write targets: path id first, then body id.
+
+        Retail addresses a squad through PUT /squad/{id}; the squad hub also
+        echoes the id in the body.  Honouring both is what lets a client address
+        anything other than the single active squad.
+        """
+        for candidate in (requested_id, document.get("squadId"), document.get("id")):
+            try:
+                value = int(candidate)
+            except (TypeError, ValueError):
+                continue
+            if 0 < value <= 2_147_483_647:
+                return value
+        return 0
+
+    def _set_active_squad_locked(
+        self, connection: sqlite3.Connection, persona_id: int, squad_id: int, force: bool = True
+    ) -> None:
+        """Point the persona at one squad, leaving exactly one active row.
+
+        ``force=False`` only promotes the squad when nothing else is active, so
+        saving an unselected squad cannot steal the match squad from the one the
+        user actually picked.
+        """
+        if squad_id <= 0:
+            return
+        if not force:
+            other = connection.execute(
+                "SELECT squad_id FROM squads WHERE persona_id = ? AND active = 1 AND squad_id != ? ORDER BY squad_id LIMIT 1",
+                (int(persona_id), int(squad_id)),
+            ).fetchone()
+            if other is not None:
+                connection.execute(
+                    "UPDATE squads SET active = 0 WHERE persona_id = ? AND squad_id = ?",
+                    (int(persona_id), int(squad_id)),
                 )
                 connection.execute(
-                    "UPDATE items SET item_type = ?, pile = ?, payload = ? WHERE item_id = ? AND persona_id = ?",
-                    (
-                        PLAYER_ITEM_TYPE, "squad" if in_squad else "club",
-                        json.dumps(payload, separators=(",", ":"), ensure_ascii=False),
-                        item_id, persona_id,
-                    ),
+                    "UPDATE fut_users SET active_squad_id = ? WHERE persona_id = ?",
+                    (int(other["squad_id"]), int(persona_id)),
                 )
+                return
+        connection.execute("UPDATE squads SET active = 0 WHERE persona_id = ?", (int(persona_id),))
+        connection.execute(
+            "UPDATE squads SET active = 1 WHERE persona_id = ? AND squad_id = ?",
+            (int(persona_id), int(squad_id)),
+        )
+        connection.execute(
+            "UPDATE fut_users SET active_squad_id = ? WHERE persona_id = ?", (int(squad_id), int(persona_id))
+        )
+
+    def create_squad(self, document: dict[str, Any]) -> dict[str, Any]:
+        """Create a squad for ``POST /squad`` with a zero id.
+
+        The FIFA 14 squad hub creates both an empty squad and a copy of an
+        existing one through this exact request: no id in the path and ``id: 0``
+        in the body.  Resolving that to the active squad is what made "create
+        squad" silently overwrite the club's only squad.  The new squad is
+        deliberately not selected, so creating one cannot swap the match squad
+        for an empty XI; the client selects it explicitly or by saving it.
+        """
+        if not isinstance(document, dict):
+            raise ValueError("squad body must be a JSON object")
+        with self._lock, closing(self._connect()) as connection, connection:
+            persona_id = int(self._identity(connection)["persona_id"])
+            self._ensure_fut_user_locked(connection)
+            cursor = connection.execute(
+                "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating) "
+                "VALUES (?, ?, ?, 0, 0, 0)",
+                (
+                    persona_id,
+                    str(document.get("squadName") or "New Squad").strip()[:32] or "New Squad",
+                    str(document.get("formation") or "f442"),
+                ),
+            )
+            squad_id = int(cursor.lastrowid)
+            for slot_index in range(23):
+                self._write_squad_slot_locked(connection, squad_id, slot_index, None)
+        payload = dict(document)
+        payload["id"] = squad_id
+        payload["squadId"] = squad_id
+        payload.setdefault("active", False)
+        self.save_squad(payload, requested_id=squad_id)
+        return self.squad_detail(squad_id)
+
+    def update_squad_metadata(self, squad_id: int, document: dict[str, Any]) -> dict[str, Any]:
+        """Apply a players-less squad write: name, formation and scalar state.
+
+        Renames arrive as ``PUT /squad/{id}`` with a body of just ``id`` and
+        ``squadName``.  The tournament handoff uses the same shape to send only
+        captain/kicktakers, so only members actually present are written.
+        """
+        assignments: list[str] = []
+        values: list[Any] = []
+        name = document.get("squadName")
+        if isinstance(name, str) and name.strip():
+            assignments.append("squad_name = ?")
+            values.append(name.strip()[:32])
+        formation = document.get("formation")
+        if isinstance(formation, str) and formation.strip():
+            assignments.append("formation = ?")
+            values.append(formation.strip())
+        for key, column in (("chemistry", "chemistry"), ("starRating", "star_rating")):
+            if key in document:
+                assignments.append(f"{column} = ?")
+                values.append(self._bounded_int(document.get(key), 0, minimum=0, maximum=100))
+        if not assignments:
+            return self.squad_list()
+        with self._lock, closing(self._connect()) as connection, connection:
+            persona_id = int(self._identity(connection)["persona_id"])
+            connection.execute(
+                f"UPDATE squads SET {', '.join(assignments)} WHERE persona_id = ? AND squad_id = ?",
+                (*values, persona_id, int(squad_id)),
+            )
+        return self.squad_list()
+
+    def set_active_squad(self, squad_id: int) -> dict[str, Any]:
+        """Select which existing squad the club and match flows use."""
+        with self._lock, closing(self._connect()) as connection, connection:
+            persona_id = int(self._identity(connection)["persona_id"])
+            self._ensure_fut_user_locked(connection)
+            row = connection.execute(
+                "SELECT squad_id FROM squads WHERE persona_id = ? AND squad_id = ?",
+                (persona_id, int(squad_id)),
+            ).fetchone()
+            if row is not None:
+                self._set_active_squad_locked(connection, persona_id, int(squad_id))
+        return self.squad_list()
+
+    def delete_squad(self, squad_id: int) -> dict[str, Any]:
+        """Remove one squad, keeping at least one squad and one active selection.
+
+        No card is destroyed: players freed by the delete return to My Club, which
+        is what retail squad deletion does.  Deleting the final remaining squad is
+        refused because the match flows always need an active squad document.
+        """
+        with self._lock, closing(self._connect()) as connection, connection:
+            persona_id = int(self._identity(connection)["persona_id"])
+            self._ensure_fut_user_locked(connection)
+            rows = connection.execute(
+                "SELECT squad_id, active FROM squads WHERE persona_id = ? ORDER BY squad_id", (persona_id,)
+            ).fetchall()
+            target = next((row for row in rows if int(row["squad_id"]) == int(squad_id)), None)
+            if target is not None and len(rows) > 1:
+                connection.execute("DELETE FROM squad_players WHERE squad_id = ?", (int(squad_id),))
+                connection.execute(
+                    "DELETE FROM squads WHERE persona_id = ? AND squad_id = ?", (persona_id, int(squad_id))
+                )
+                if bool(target["active"]):
+                    remaining = [int(row["squad_id"]) for row in rows if int(row["squad_id"]) != int(squad_id)]
+                    self._set_active_squad_locked(connection, persona_id, remaining[0])
+                self._sync_player_piles_locked(connection, persona_id)
         return self.squad_list()
 
     def squad_list(self) -> dict[str, Any]:

--- a/server/local_identity.py
+++ b/server/local_identity.py
@@ -324,6 +324,11 @@ class LocalIdentityStore:
                 connection.execute("ALTER TABLE squads ADD COLUMN chemistry INTEGER NOT NULL DEFAULT 0")
             if "star_rating" not in squad_columns:
                 connection.execute("ALTER TABLE squads ADD COLUMN star_rating INTEGER NOT NULL DEFAULT 0")
+            # A squad the user has deliberately saved is never auto-populated
+            # again.  Legacy rows default to 0 so the existing recovery path still
+            # protects clubs migrated from a build that could zero their squad.
+            if "client_saved" not in squad_columns:
+                connection.execute("ALTER TABLE squads ADD COLUMN client_saved INTEGER NOT NULL DEFAULT 0")
             squad_player_columns = {row[1] for row in connection.execute("PRAGMA table_info(squad_players)").fetchall()}
             if "kit_number" not in squad_player_columns:
                 connection.execute("ALTER TABLE squad_players ADD COLUMN kit_number INTEGER NOT NULL DEFAULT 0")
@@ -1947,6 +1952,14 @@ class LocalIdentityStore:
         if fut_user is None:
             return False
         squad_id = int(fut_user["active_squad_id"])
+        squad_row = connection.execute(
+            "SELECT client_saved FROM squads WHERE squad_id = ?", (squad_id,)
+        ).fetchone()
+        if squad_row is not None and int(squad_row["client_saved"] or 0):
+            # The user built this squad.  A short XI is their choice, not the
+            # zeroed-squad corruption this recovery exists for, so never fill the
+            # empty slots with arbitrary owned cards.
+            return False
         nonzero = int(connection.execute(
             "SELECT COUNT(*) FROM squad_players WHERE squad_id = ? AND item_id > 0", (squad_id,)
         ).fetchone()[0])
@@ -4716,26 +4729,27 @@ class LocalIdentityStore:
                     "WHERE persona_id = ? AND squad_id = ?", (persona_id, squad_id)
                 ).fetchone()
             if row is None:
-                insert_values = (
-                    requested_name or "Local XI",
-                    requested_formation or "f442",
-                    self._bounded_int(requested_chemistry, 0, minimum=0, maximum=100),
-                    self._bounded_int(requested_rating, 0, minimum=0, maximum=100),
+                # Squads are created through POST /squad with a zero id.  A write
+                # naming an id this persona does not own is stale client state --
+                # typically the editor still holding a squad that was just deleted
+                # -- so it must not resurrect that squad.  Creating here is only a
+                # bootstrap safety net for a persona that owns no squad at all.
+                owns_any = connection.execute(
+                    "SELECT 1 FROM squads WHERE persona_id = ? LIMIT 1", (persona_id,)
+                ).fetchone()
+                if owns_any is not None:
+                    return self.squad_list()
+                cursor = connection.execute(
+                    "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating) VALUES (?, ?, ?, 0, ?, ?)",
+                    (
+                        persona_id,
+                        requested_name or "Local XI",
+                        requested_formation or "f442",
+                        self._bounded_int(requested_chemistry, 0, minimum=0, maximum=100),
+                        self._bounded_int(requested_rating, 0, minimum=0, maximum=100),
+                    ),
                 )
-                if squad_id > 0:
-                    # A write naming an unknown squad creates it under the id the
-                    # client chose, so its follow-up GET /squad/{id} resolves.
-                    connection.execute(
-                        "INSERT INTO squads (squad_id, persona_id, squad_name, formation, active, chemistry, star_rating) "
-                        "VALUES (?, ?, ?, ?, 0, ?, ?)",
-                        (squad_id, persona_id, *insert_values),
-                    )
-                else:
-                    cursor = connection.execute(
-                        "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating) VALUES (?, ?, ?, 0, ?, ?)",
-                        (persona_id, *insert_values),
-                    )
-                    squad_id = int(cursor.lastrowid)
+                squad_id = int(cursor.lastrowid)
                 row = connection.execute(
                     "SELECT squad_id,squad_name,formation,active,chemistry,star_rating FROM squads WHERE squad_id=?",
                     (squad_id,),
@@ -4798,7 +4812,7 @@ class LocalIdentityStore:
                 return self.squad_list()
 
             connection.execute(
-                "UPDATE squads SET squad_name = ?, formation = ?, chemistry = ?, star_rating = ? WHERE squad_id = ?",
+                "UPDATE squads SET squad_name = ?, formation = ?, chemistry = ?, star_rating = ?, client_saved = 1 WHERE squad_id = ?",
                 (squad_name, formation, chemistry, star_rating, squad_id),
             )
             self._set_active_squad_locked(connection, persona_id, squad_id, force=should_activate)
@@ -4919,8 +4933,8 @@ class LocalIdentityStore:
             persona_id = int(self._identity(connection)["persona_id"])
             self._ensure_fut_user_locked(connection)
             cursor = connection.execute(
-                "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating) "
-                "VALUES (?, ?, ?, 0, 0, 0)",
+                "INSERT INTO squads (persona_id, squad_name, formation, active, chemistry, star_rating, client_saved) "
+                "VALUES (?, ?, ?, 0, 0, 0, 1)",
                 (
                     persona_id,
                     str(document.get("squadName") or "New Squad").strip()[:32] or "New Squad",

--- a/server/probe.py
+++ b/server/probe.py
@@ -3499,11 +3499,53 @@ class HttpProbe(BaseHTTPRequestHandler):
                 request = None
                 tail = path_without_query.rsplit("/", 1)[-1]
                 requested_id = int(tail) if tail.isdigit() else None
-                if effective_method in {"PUT", "POST"} and body:
-                    request = json.loads(body.decode("utf-8"))
-                    identity_store.save_squad(request, requested_id=requested_id)
+                is_active_route = path_without_query.startswith("/ut/game/fifa14/squad/active")
+                if effective_method == "DELETE" and requested_id is not None and hasattr(identity_store, "delete_squad"):
+                    identity_store.delete_squad(requested_id)
+                    response = identity_store.squad_list_compact() if hasattr(identity_store, "squad_list_compact") else identity_store.squad_list()
+                    response_name = "squad-deleted-list"
+                elif (
+                    is_active_route
+                    and requested_id is not None
+                    and effective_method in {"PUT", "POST"}
+                    and hasattr(identity_store, "set_active_squad")
+                ):
+                    # PUT /squad/active/{id} selects an existing squad without
+                    # rewriting any slot.
+                    identity_store.set_active_squad(requested_id)
                     response = identity_store.squad_detail(requested_id) if hasattr(identity_store, "squad_detail") else identity_store.active_squad_document()
-                    response_name = "squad-saved-detail-beta222"
+                    response_name = "squad-active-selected"
+                elif effective_method in {"PUT", "POST"} and body:
+                    request = json.loads(body.decode("utf-8"))
+                    body_squad_id = 0
+                    if isinstance(request, dict):
+                        try:
+                            body_squad_id = int(request.get("squadId") or request.get("id") or 0)
+                        except (TypeError, ValueError):
+                            body_squad_id = 0
+                    if (
+                        effective_method == "POST"
+                        and path_without_query == "/ut/game/fifa14/squad"
+                        and requested_id is None
+                        and body_squad_id <= 0
+                        and hasattr(identity_store, "create_squad")
+                    ):
+                        # The squad hub creates an empty squad and copies an
+                        # existing one through this exact request: no path id and
+                        # id 0 in the body.
+                        response = identity_store.create_squad(request)
+                        response_name = "squad-created-detail"
+                        emit("fut-squad-created",
+                             path=self.path,
+                             squad_id=int(response.get("id", 0)) if isinstance(response, dict) else 0,
+                             squad_name=response.get("squadName") if isinstance(response, dict) else None)
+                    else:
+                        identity_store.save_squad(request, requested_id=requested_id)
+                        # Echo back the squad that was written, which is not always
+                        # the active one once more than one squad exists.
+                        detail_id = requested_id if requested_id else (body_squad_id or None)
+                        response = identity_store.squad_detail(detail_id) if hasattr(identity_store, "squad_detail") else identity_store.active_squad_document()
+                        response_name = "squad-saved-detail-beta222"
                 elif path_without_query == "/ut/game/fifa14/squad/list":
                     response = identity_store.squad_list_compact() if hasattr(identity_store, "squad_list_compact") else identity_store.squad_list()
                     response_name = "squad-list-compact-beta222"

--- a/server/probe.py
+++ b/server/probe.py
@@ -2368,6 +2368,21 @@ class HttpProbe(BaseHTTPRequestHandler):
             )
         )
 
+    @staticmethod
+    def _fut_squad_delete_id(path: str) -> int | None:
+        """Return the squad id for FIFA 14's tunnelled squad delete, else None.
+
+        The client cannot issue a DELETE verb, so the squad hub deletes through
+        ``GET /ut/delete/game/fifa14/squad/{id}`` -- the same ``/ut/delete/``
+        tunnel it uses for logout at ``/ut/delete/auth``.  Without this the route
+        fell through to the generic unmapped-route acknowledgement, which is why
+        a deleted squad was acknowledged but never actually removed.
+        """
+        match = re.fullmatch(
+            r"/ut/delete/game/fifa14/squad/(\d+)", str(path).partition("?")[0], re.IGNORECASE
+        )
+        return int(match.group(1)) if match else None
+
     def _handle(self) -> None:
         length = int(self.headers.get("content-length", "0"))
         body = self.rfile.read(min(length, 1_048_576)) if length else b""
@@ -3489,6 +3504,29 @@ class HttpProbe(BaseHTTPRequestHandler):
             )
         elif (
             getattr(self.server, "probe_name", "http") == "fut-http"
+            and self._fut_squad_delete_id(path_without_query) is not None
+            and identity_store is not None
+        ):
+            squad_id = int(self._fut_squad_delete_id(path_without_query) or 0)
+            remaining: list[int] = []
+            if hasattr(identity_store, "delete_squad"):
+                listing = identity_store.delete_squad(squad_id)
+                if isinstance(listing, dict):
+                    remaining = [
+                        int(row.get("id", 0)) for row in listing.get("squadList", []) if isinstance(row, dict)
+                    ]
+            # The client re-reads /squad/list immediately afterwards, so keep the
+            # empty acknowledgement this route has always answered with rather
+            # than inventing a delete response contract.
+            payload = build_fut_json_payload({})
+            self.send_response(200)
+            self.send_header("content-type", "application/json; charset=utf-8")
+            self.send_header("cache-control", "no-store")
+            emit("fut-squad-deleted", path=self.path, squad_id=squad_id, remaining=remaining)
+            emit("fut-http-response", method=self.command, effective_method=effective_method,
+                 path=self.path, response_name="squad-deleted-ack", status=200, bytes=len(payload))
+        elif (
+            getattr(self.server, "probe_name", "http") == "fut-http"
             and (
                 path_without_query == "/ut/game/fifa14/squad"
                 or path_without_query.startswith("/ut/game/fifa14/squad/")
@@ -3504,6 +3542,8 @@ class HttpProbe(BaseHTTPRequestHandler):
                     identity_store.delete_squad(requested_id)
                     response = identity_store.squad_list_compact() if hasattr(identity_store, "squad_list_compact") else identity_store.squad_list()
                     response_name = "squad-deleted-list"
+                    emit("fut-squad-deleted", path=self.path, squad_id=requested_id,
+                         remaining=[int(row.get("id", 0)) for row in response.get("squad", [])] if isinstance(response, dict) else [])
                 elif (
                     is_active_route
                     and requested_id is not None

--- a/tools/summarize_fifa14_squad_requests.py
+++ b/tools/summarize_fifa14_squad_requests.py
@@ -154,12 +154,27 @@ def main() -> int:
         for event in events if event.get("kind") == "fut-squad-state-beta222"
     ]
 
+    # A delete the client sends somewhere other than /squad would be invisible in
+    # the filtered view above, so keep every non-GET request in the capture.
+    other_writes = [
+        summarize_request(event)
+        for event in events
+        if event.get("kind") == "http-probe"
+        and str(event.get("method", "")).upper() not in {"GET", "HEAD"}
+        and "/squad" not in str(event.get("path", "")).lower()
+    ]
     writes = [row for row in requests if str(row.get("method")) in {"PUT", "POST"} or row.get("methodOverride") in {"PUT", "POST"}]
     addressed = sorted({row["pathSquadId"] for row in requests if row["pathSquadId"]} |
                        {int(row.get("bodySquadId", 0)) for row in requests if row.get("bodySquadId")})
     written = sorted({row["pathSquadId"] for row in writes if row["pathSquadId"]} |
                      {int(row.get("bodySquadId", 0)) for row in writes if row.get("bodySquadId")})
-    deletes = [row for row in requests if str(row.get("method")) == "DELETE" or row.get("methodOverride") == "DELETE"]
+    # FIFA 14 has no DELETE verb: the squad hub deletes through
+    # GET /ut/delete/game/fifa14/squad/{id}, the same tunnel as /ut/delete/auth.
+    deletes = [
+        row for row in requests
+        if str(row.get("method")) == "DELETE" or row.get("methodOverride") == "DELETE"
+        or str(row.get("path", "")).lower().startswith("/ut/delete/")
+    ]
 
     findings: list[str] = []
     if not events:
@@ -168,19 +183,33 @@ def main() -> int:
         findings.append("The client made no /squad request at all in this capture.")
     else:
         if not writes:
-            findings.append("The client only read squads; it never sent a PUT/POST, so no squad could be created.")
-        if len(written) <= 1:
+            findings.append("The client only read or deleted squads in this capture; it sent no PUT/POST.")
+        elif len(written) <= 1:
             findings.append(
                 "Every squad write addressed the same id "
                 f"{written or '(none in path or body)'}: the in-game action is not asking the server for a new squad. "
-                "The server creates a squad only when a write names an unused id."
+                "Squads are created by POST /squad carrying id 0."
             )
         if writes and not any(row.get("pathSquadId") or row.get("bodySquadId") for row in writes):
             findings.append(
                 "Squad writes carry no id in the path or the body, so they always fall back to the active squad."
             )
-        if not deletes:
-            findings.append("No DELETE /squad/{id} was seen; squad deletion was not exercised.")
+        if deletes:
+            unhandled = [
+                response for response in responses
+                if str(response.get("path", "")).lower().startswith("/ut/delete/")
+                and str(response.get("responseName", "")).startswith("unmapped")
+            ]
+            findings.append(
+                f"Squad deletes seen for ids {sorted({row['pathSquadId'] for row in deletes if row['pathSquadId']})}."
+                + (" Some were answered by the generic unmapped-route ack and did nothing." if unhandled else "")
+            )
+        else:
+            findings.append(
+                "No squad delete was seen. If a squad was deleted in-game during this capture, "
+                "the client sent no delete request the server could act on -- check nonSquadWrites for "
+                "the request it sent instead."
+            )
     if not findings:
         findings.append(f"The client addressed multiple squad ids: {written}.")
 
@@ -194,6 +223,7 @@ def main() -> int:
         "recentRequests": requests[-max(arguments.limit, 0):],
         "recentResponses": responses[-max(arguments.limit, 0):],
         "recentSquadState": states[-max(arguments.limit, 0):],
+        "nonSquadWrites": other_writes[-max(arguments.limit, 0):],
         "persistedState": database_state(arguments.database),
     }, indent=2))
     return 0

--- a/tools/summarize_fifa14_squad_requests.py
+++ b/tools/summarize_fifa14_squad_requests.py
@@ -80,7 +80,7 @@ def summarize_request(event: dict[str, Any]) -> dict[str, Any]:
     if isinstance(headers, dict):
         override = headers.get("X-HTTP-Method-Override") or headers.get("x-http-method-override")
         if override:
-            record["methodOverride"] = str(override)
+            record["methodOverride"] = str(override).upper()
     if document is not None:
         players = document.get("players")
         record["bodySquadId"] = body_squad_id(document)

--- a/tools/summarize_fifa14_squad_requests.py
+++ b/tools/summarize_fifa14_squad_requests.py
@@ -172,8 +172,8 @@ def main() -> int:
     # GET /ut/delete/game/fifa14/squad/{id}, the same tunnel as /ut/delete/auth.
     deletes = [
         row for row in requests
-        if str(row.get("method")) == "DELETE" or row.get("methodOverride") == "DELETE"
-        or str(row.get("path", "")).lower().startswith("/ut/delete/")
+        if str(row.get("method", "")).upper() == "DELETE" or str(row.get("methodOverride", "")).upper() == "DELETE"
+        or str(row.get("path", "")).lower().startswith("/ut/delete/game/fifa14/squad/")
     ]
 
     findings: list[str] = []

--- a/tools/summarize_fifa14_squad_requests.py
+++ b/tools/summarize_fifa14_squad_requests.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Summarize every /squad request FIFA 14 made, plus the persisted squad state.
+
+The local server can only create a second squad if the client actually addresses
+one -- by path (``PUT /squad/{id}``) or by an ``id``/``squadId`` in the body.
+This reads the probe capture written by the launcher and reports exactly which
+squad ids the client asked for, so an in-game "create squad" that does nothing
+can be told apart from a server that refused the write.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+from typing import Any
+
+DEFAULT_LOG = Path(__file__).resolve().parents[1] / "artifacts" / "redirect-probe.log"
+DEFAULT_DATABASE = Path(os.environ.get("LOCALAPPDATA", "")) / "FIFA14LocalFUTBeta" / "local-fut-beta-v2410.sqlite3"
+
+
+def load_json_lines(path: Path) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    if not path.is_file():
+        return events
+    for number, raw_line in enumerate(path.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            item = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(item, dict):
+            item.setdefault("_line", number)
+            events.append(item)
+    return events
+
+
+def decode_body(event: dict[str, Any]) -> dict[str, Any] | None:
+    raw = event.get("body_hex")
+    if not isinstance(raw, str) or not raw:
+        return None
+    try:
+        document = json.loads(bytes.fromhex(raw).decode("utf-8", errors="replace"))
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return document if isinstance(document, dict) else None
+
+
+def body_squad_id(document: dict[str, Any]) -> int:
+    for key in ("squadId", "id"):
+        try:
+            value = int(document.get(key))
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            return value
+    return 0
+
+
+def path_squad_id(path: str) -> int:
+    tail = path.partition("?")[0].rstrip("/").rsplit("/", 1)[-1]
+    return int(tail) if tail.isdigit() else 0
+
+
+def summarize_request(event: dict[str, Any]) -> dict[str, Any]:
+    path = str(event.get("path", ""))
+    document = decode_body(event)
+    record: dict[str, Any] = {
+        "line": event.get("_line"),
+        "time": event.get("time"),
+        "method": str(event.get("method", "")),
+        "path": path,
+        "pathSquadId": path_squad_id(path),
+    }
+    headers = event.get("headers")
+    if isinstance(headers, dict):
+        override = headers.get("X-HTTP-Method-Override") or headers.get("x-http-method-override")
+        if override:
+            record["methodOverride"] = str(override)
+    if document is not None:
+        players = document.get("players")
+        record["bodySquadId"] = body_squad_id(document)
+        record["bodyKeys"] = sorted(document.keys())
+        if isinstance(document.get("squadName"), str):
+            record["squadName"] = document["squadName"]
+        if "active" in document:
+            record["active"] = document["active"]
+        if isinstance(players, list):
+            record["playerSlots"] = len(players)
+            record["filledSlots"] = sum(
+                1 for row in players
+                if isinstance(row, dict) and isinstance(row.get("itemData"), dict)
+                and int((row["itemData"].get("id") or row["itemData"].get("itemId") or 0) or 0) > 0
+            )
+    return record
+
+
+def database_state(database: Path) -> dict[str, Any]:
+    if not database.is_file():
+        return {"database": str(database), "found": False}
+    with closing(sqlite3.connect(database)) as connection:
+        connection.row_factory = sqlite3.Row
+        squads = [
+            {
+                "squadId": int(row["squad_id"]),
+                "personaId": int(row["persona_id"]),
+                "squadName": row["squad_name"],
+                "formation": row["formation"],
+                "active": bool(row["active"]),
+                "filledSlots": int(connection.execute(
+                    "SELECT COUNT(*) FROM squad_players WHERE squad_id = ? AND item_id > 0", (int(row["squad_id"]),)
+                ).fetchone()[0]),
+            }
+            for row in connection.execute("SELECT * FROM squads ORDER BY squad_id").fetchall()
+        ]
+        active_ids = [
+            int(row["active_squad_id"]) for row in connection.execute(
+                "SELECT active_squad_id FROM fut_users WHERE active_squad_id IS NOT NULL"
+            ).fetchall()
+        ]
+    return {"database": str(database), "found": True, "squads": squads, "activeSquadIds": active_ids}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--log", type=Path, default=DEFAULT_LOG, help="probe capture (artifacts/redirect-probe.log)")
+    parser.add_argument("--database", type=Path, default=DEFAULT_DATABASE, help="persistent BETA identity database")
+    parser.add_argument("--limit", type=int, default=40, help="most recent squad requests to print")
+    arguments = parser.parse_args()
+
+    events = load_json_lines(arguments.log)
+    requests = [
+        summarize_request(event)
+        for event in events
+        if event.get("kind") == "http-probe" and "/squad" in str(event.get("path", "")).lower()
+    ]
+    responses = [
+        {
+            "line": event.get("_line"), "method": event.get("effective_method", event.get("method")),
+            "path": event.get("path"), "responseName": event.get("response_name"), "status": event.get("status"),
+        }
+        for event in events
+        if event.get("kind") == "fut-http-response" and "/squad" in str(event.get("path", "")).lower()
+    ]
+    states = [
+        {
+            "line": event.get("_line"), "method": event.get("method"), "path": event.get("path"),
+            "incomingFilled": event.get("incoming_filled"), "outgoingFilled": event.get("outgoing_filled"),
+        }
+        for event in events if event.get("kind") == "fut-squad-state-beta222"
+    ]
+
+    writes = [row for row in requests if str(row.get("method")) in {"PUT", "POST"} or row.get("methodOverride") in {"PUT", "POST"}]
+    addressed = sorted({row["pathSquadId"] for row in requests if row["pathSquadId"]} |
+                       {int(row.get("bodySquadId", 0)) for row in requests if row.get("bodySquadId")})
+    written = sorted({row["pathSquadId"] for row in writes if row["pathSquadId"]} |
+                     {int(row.get("bodySquadId", 0)) for row in writes if row.get("bodySquadId")})
+    deletes = [row for row in requests if str(row.get("method")) == "DELETE" or row.get("methodOverride") == "DELETE"]
+
+    findings: list[str] = []
+    if not events:
+        findings.append(f"No probe capture at {arguments.log}. Launch through RUN_FIFA14_LOCAL_BETA.cmd first.")
+    elif not requests:
+        findings.append("The client made no /squad request at all in this capture.")
+    else:
+        if not writes:
+            findings.append("The client only read squads; it never sent a PUT/POST, so no squad could be created.")
+        if len(written) <= 1:
+            findings.append(
+                "Every squad write addressed the same id "
+                f"{written or '(none in path or body)'}: the in-game action is not asking the server for a new squad. "
+                "The server creates a squad only when a write names an unused id."
+            )
+        if writes and not any(row.get("pathSquadId") or row.get("bodySquadId") for row in writes):
+            findings.append(
+                "Squad writes carry no id in the path or the body, so they always fall back to the active squad."
+            )
+        if not deletes:
+            findings.append("No DELETE /squad/{id} was seen; squad deletion was not exercised.")
+    if not findings:
+        findings.append(f"The client addressed multiple squad ids: {written}.")
+
+    print(json.dumps({
+        "log": str(arguments.log),
+        "squadRequests": len(requests),
+        "squadWrites": len(writes),
+        "squadIdsAddressed": addressed,
+        "squadIdsWritten": written,
+        "findings": findings,
+        "recentRequests": requests[-max(arguments.limit, 0):],
+        "recentResponses": responses[-max(arguments.limit, 0):],
+        "recentSquadState": states[-max(arguments.limit, 0):],
+        "persistedState": database_state(arguments.database),
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_fifa14_multi_squad.py
+++ b/tools/verify_fifa14_multi_squad.py
@@ -1,0 +1,253 @@
+"""Verify that a persona can own, address and delete more than one FUT squad.
+
+The persistent schema was always keyed by ``squad_id``; what pinned the local
+server to a single squad was the write path always resolving to the active
+squad, always force-activating whatever it wrote, and demoting every player not
+in that one squad back to My Club.  These checks pin the fixed behaviour.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import tempfile
+from contextlib import closing
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SERVER = ROOT / "server"
+if str(SERVER) not in sys.path:
+    sys.path.insert(0, str(SERVER))
+
+import beta_identity as beta_identity_module
+from beta_identity import BetaIdentityStore
+
+
+def fail(message: str) -> None:
+    raise AssertionError(message)
+
+
+def squad_by_id(store: BetaIdentityStore, squad_id: int) -> dict:
+    for row in store.squad_list().get("squadList", []):
+        if int(row.get("id", 0)) == int(squad_id):
+            return row
+    fail(f"squad {squad_id} is missing from /squad list")
+    return {}
+
+
+def item_ids(squad: dict) -> list[int]:
+    return [int((row.get("itemData") or {}).get("id", 0) or 0) for row in squad.get("players", [])]
+
+
+def piles(db: Path, ids: list[int]) -> dict[int, str]:
+    with closing(sqlite3.connect(db)) as connection:
+        return {
+            int(row[0]): str(row[1]).lower()
+            for row in connection.execute(
+                "SELECT item_id, pile FROM items WHERE item_id IN (%s)" % ",".join("?" * len(ids)),
+                [int(value) for value in ids],
+            ).fetchall()
+        }
+
+
+def owned_item_count(db: Path) -> int:
+    with closing(sqlite3.connect(db)) as connection:
+        return int(connection.execute("SELECT COUNT(*) FROM items").fetchone()[0])
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        db = Path(td) / "beta.sqlite3"
+        report = Path(td) / "fifa14-match-assets-v2411-beta222.json"
+        report.write_text(json.dumps({"catalog": {"kits": [], "stadiums": [], "badges": []}}), encoding="utf-8")
+        beta_identity_module.MATCH_ASSET_REPORT = report
+        store = BetaIdentityStore(str(db), "existing")
+
+        first = store.squad_list()["squadList"][0]
+        first_id = int(first["id"])
+        first_ids = item_ids(first)
+        starters = [value for value in first_ids if value > 0][:11]
+        if len(starters) < 11:
+            fail(f"starter squad must be populated before this check: {first_ids}")
+
+        # 1. A write addressed to an unknown id creates a second squad under that
+        #    id instead of overwriting the first.
+        second_id = first_id + 1
+        second_players = [
+            {"index": index, "itemData": {"id": starters[index] if index < 11 else 0}, "kitNumber": 0}
+            for index in range(23)
+        ]
+        store.save_squad(
+            {"id": second_id, "squadName": "Second XI", "formation": "f433",
+             "chemistry": 42, "starRating": 55, "players": second_players},
+            requested_id=second_id,
+        )
+        squads = store.squad_list()["squadList"]
+        if len(squads) != 2:
+            fail(f"saving an unknown squad id must create a second squad, got {[s['id'] for s in squads]}")
+        second = squad_by_id(store, second_id)
+        if str(second.get("squadName")) != "Second XI" or str(second.get("formation")) != "f433":
+            fail(f"second squad metadata was not persisted: {second}")
+        if len(second.get("players", [])) != 23:
+            fail(f"second squad must serialize all 23 slots: {len(second.get('players', []))}")
+        if item_ids(squad_by_id(store, first_id)) != first_ids:
+            fail("creating a second squad mutated the first squad's slots")
+
+        # 1b. The shapes the FIFA 14 squad hub actually sends, from the BETA
+        #     capture: POST /squad with no path id and id 0 creates a squad -- an
+        #     empty one, or a copy carrying the source squad's 23 slots.  Both
+        #     used to resolve to the active squad and overwrite the only squad.
+        created_empty = store.create_squad({
+            "id": 0, "squadName": "test", "formation": "f442",
+            "chemistry": 0, "rating": 0, "starRating": 0, "manager": [], "players": [],
+        })
+        empty_id = int(created_empty.get("id", 0))
+        if empty_id in (0, first_id, second_id):
+            fail(f"POST /squad with id 0 must create a new squad, got id {empty_id}")
+        if str(created_empty.get("squadName")) != "test":
+            fail(f"created squad kept the wrong name: {created_empty}")
+        if any(value > 0 for value in item_ids(created_empty)):
+            fail("an empty create must not inherit another squad's players")
+        if int(store.squad_list_compact()["activeSquadId"]) == empty_id:
+            fail("creating an empty squad must not become the match squad")
+        if item_ids(squad_by_id(store, first_id)) != first_ids:
+            fail("creating a squad mutated the first squad's slots")
+
+        created_copy = store.create_squad({
+            "id": 0, "squadName": "COPY  Second XI", "formation": "f433d",
+            "chemistry": 42, "rating": 55, "starRating": 55, "manager": [],
+            "players": second_players,
+        })
+        copy_id = int(created_copy.get("id", 0))
+        if copy_id in (0, first_id, second_id, empty_id):
+            fail(f"copying a squad must create a distinct squad, got id {copy_id}")
+        if item_ids(created_copy) != item_ids(squad_by_id(store, second_id)):
+            fail("a copy create must carry the copied slots")
+        if len(store.squad_list()["squadList"]) != 4:
+            fail("expected four squads after two creates")
+
+        # 1c. A players-less PUT is the squad hub's rename.  Dropping it made
+        #     renames revert on the next list refresh.
+        store.save_squad({"id": empty_id, "squadName": "local"}, requested_id=empty_id)
+        if str(squad_by_id(store, empty_id).get("squadName")) != "local":
+            fail("a players-less PUT carrying squadName must persist the rename")
+        if int(store.squad_list_compact()["activeSquadId"]) == empty_id:
+            fail("a rename must not change the active squad")
+        # The tournament handoff uses the same shape for captain/kicktakers only.
+        before_handoff = squad_by_id(store, first_id)
+        store.save_squad({"id": first_id, "captain": starters[0], "kicktakers": [starters[0]]})
+        if squad_by_id(store, first_id) != before_handoff:
+            fail("a captain/kicktakers-only PUT must not alter squad state")
+
+        # 1d. Leaving the squad editor sends every slot and the formation but no
+        #     squadName.  Absent metadata must keep its stored value: defaulting
+        #     it reverted every renamed squad to "Local XI" on exit.
+        store.save_squad(
+            {"id": copy_id, "formation": "f4312", "players": second_players,
+             "chemistry": 44, "starRating": 57},
+            requested_id=copy_id,
+        )
+        edited = squad_by_id(store, copy_id)
+        if str(edited.get("squadName")) != "COPY  Second XI":
+            fail(f"a nameless editor write reverted the squad name: {edited.get('squadName')}")
+        if str(edited.get("formation")) != "f4312":
+            fail(f"a nameless editor write must still persist the formation: {edited}")
+        store.save_squad({"id": copy_id, "players": second_players}, requested_id=copy_id)
+        kept = squad_by_id(store, copy_id)
+        if str(kept.get("squadName")) != "COPY  Second XI" or str(kept.get("formation")) != "f4312":
+            fail(f"a slots-only write must keep name and formation: {kept}")
+        if int(kept.get("chemistry", -1)) != 44 or int(kept.get("starRating", -1)) != 57:
+            fail(f"a slots-only write must keep chemistry and rating: {kept}")
+
+        store.delete_squad(empty_id)
+        store.delete_squad(copy_id)
+        if len(store.squad_list()["squadList"]) != 2:
+            fail("failed to return to the two-squad fixture")
+
+        # 2. Cards fielded by the first squad keep pile 'squad' after a write to
+        #    the second one.  This is the regression that made multi-squad state
+        #    collapse: the save loop demoted every card outside the saved squad.
+        first_only = [value for value in first_ids if value > 0 and value not in starters]
+        if not first_only:
+            fail("expected the first squad to field cards the second one does not")
+        stale = {item: pile for item, pile in piles(db, first_only).items() if pile != "squad"}
+        if stale:
+            fail(f"cards in another squad were demoted to My Club: {stale}")
+
+        # 3. Save-with-active is unchanged (the saved squad is selected), and an
+        #    explicit active:false leaves the user's selection alone.
+        store.set_active_squad(first_id)
+        store.save_squad(
+            {"id": second_id, "squadName": "Second XI", "formation": "f433",
+             "chemistry": 42, "starRating": 55, "players": second_players},
+            requested_id=second_id,
+        )
+        if int(store.squad_list_compact()["activeSquadId"]) != second_id:
+            fail("a save without an explicit active flag must keep selecting the saved squad")
+        store.set_active_squad(first_id)
+        compact = store.squad_list_compact()
+        if int(compact["activeSquadId"]) != first_id:
+            fail(f"set_active_squad did not switch the selection: {compact}")
+        if sum(1 for row in compact["squad"] if row.get("active")) != 1:
+            fail(f"exactly one squad may be active: {compact}")
+        store.save_squad(
+            {"id": second_id, "squadName": "Second XI", "formation": "f433", "active": False,
+             "chemistry": 43, "starRating": 56, "players": second_players},
+            requested_id=second_id,
+        )
+        if int(store.squad_list_compact()["activeSquadId"]) != first_id:
+            fail("saving an unselected squad must not steal the active selection")
+        if int(squad_by_id(store, second_id).get("chemistry", 0)) != 43:
+            fail("an unselected save must still persist that squad's own state")
+
+        # 4. Details and persistence are addressable per squad.
+        if int(store.squad_detail(second_id).get("id", 0)) != second_id:
+            fail("squad_detail must return the requested squad, not the active one")
+        store = BetaIdentityStore(str(db), "existing")
+        reopened = store.squad_list()["squadList"]
+        if len(reopened) != 2 or int(store.squad_list_compact()["activeSquadId"]) != first_id:
+            fail(f"multi-squad state did not survive a store reopen: {[s['id'] for s in reopened]}")
+
+        # 5. Deleting a squad frees its cards without destroying them, and the
+        #    final remaining squad cannot be deleted.
+        owned_before = owned_item_count(db)
+        store.delete_squad(second_id)
+        squads = store.squad_list()["squadList"]
+        if len(squads) != 1 or int(squads[0]["id"]) != first_id:
+            fail(f"delete_squad removed the wrong squad: {[s['id'] for s in squads]}")
+        owned_after = owned_item_count(db)
+        if owned_after != owned_before:
+            fail(f"delete_squad destroyed owned cards: {owned_before} -> {owned_after}")
+        if item_ids(squad_by_id(store, first_id)) != first_ids:
+            fail("delete_squad disturbed the surviving squad")
+        store.delete_squad(first_id)
+        if len(store.squad_list()["squadList"]) != 1:
+            fail("the last remaining squad must not be deletable")
+        if int(store.squad_list_compact()["activeSquadId"]) != first_id:
+            fail("the persona must always keep an active squad")
+
+        # 6. Cards dropped from every squad go back to My Club.
+        benched = [value for value in first_ids if value > 0][11:]
+        if not benched:
+            fail("expected reserves to bench for the My Club check")
+        store.save_squad(
+            {"id": first_id, "squadName": str(squads[0].get("squadName")),
+             "formation": str(squads[0].get("formation")),
+             "chemistry": int(squads[0].get("chemistry", 0)),
+             "starRating": int(squads[0].get("starRating", 0)),
+             "players": [
+                 {"index": index, "itemData": {"id": starters[index] if index < 11 else 0}, "kitNumber": 0}
+                 for index in range(23)
+             ]},
+            requested_id=first_id,
+        )
+        wrong = {item: pile for item, pile in piles(db, benched).items() if pile != "club"}
+        if wrong:
+            fail(f"cards removed from every squad must return to My Club: {wrong}")
+
+    print("FIFA 14 multi-squad verification passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/verify_fifa14_multi_squad.py
+++ b/tools/verify_fifa14_multi_squad.py
@@ -21,6 +21,7 @@ if str(SERVER) not in sys.path:
 
 import beta_identity as beta_identity_module
 from beta_identity import BetaIdentityStore
+from probe import HttpProbe
 
 
 def fail(message: str) -> None:
@@ -70,21 +71,29 @@ def main() -> int:
         if len(starters) < 11:
             fail(f"starter squad must be populated before this check: {first_ids}")
 
-        # 1. A write addressed to an unknown id creates a second squad under that
-        #    id instead of overwriting the first.
-        second_id = first_id + 1
+        # 1. A second squad is created through the retail create request, and a
+        #    write naming an id the persona does not own is ignored -- that write
+        #    is the editor holding a squad that was just deleted, and honouring it
+        #    resurrected the deleted squad.
         second_players = [
             {"index": index, "itemData": {"id": starters[index] if index < 11 else 0}, "kitNumber": 0}
             for index in range(23)
         ]
-        store.save_squad(
-            {"id": second_id, "squadName": "Second XI", "formation": "f433",
-             "chemistry": 42, "starRating": 55, "players": second_players},
-            requested_id=second_id,
+        created_second = store.create_squad(
+            {"id": 0, "squadName": "Second XI", "formation": "f433",
+             "chemistry": 42, "rating": 55, "starRating": 55, "manager": [], "players": second_players}
         )
+        second_id = int(created_second.get("id", 0))
         squads = store.squad_list()["squadList"]
-        if len(squads) != 2:
-            fail(f"saving an unknown squad id must create a second squad, got {[s['id'] for s in squads]}")
+        if len(squads) != 2 or second_id in (0, first_id):
+            fail(f"create must add a second squad, got {[s['id'] for s in squads]}")
+        ghost_id = max(int(row["id"]) for row in squads) + 50
+        store.save_squad(
+            {"id": ghost_id, "squadName": "Ghost XI", "formation": "f433", "players": second_players},
+            requested_id=ghost_id,
+        )
+        if len(store.squad_list()["squadList"]) != 2:
+            fail("a write naming an unknown squad id must be ignored, not create a squad")
         second = squad_by_id(store, second_id)
         if str(second.get("squadName")) != "Second XI" or str(second.get("formation")) != "f433":
             fail(f"second squad metadata was not persisted: {second}")
@@ -159,7 +168,37 @@ def main() -> int:
         if int(kept.get("chemistry", -1)) != 44 or int(kept.get("starRating", -1)) != 57:
             fail(f"a slots-only write must keep chemistry and rating: {kept}")
 
+        # 1e. A squad the user built is never auto-populated, however few players
+        #     it fields.  The active-squad recovery used to rebuild any short XI
+        #     from owned cards, which filled half-finished squads with whatever
+        #     the club happened to own.
+        short_players = [
+            {"index": index, "itemData": {"id": starters[index] if index < 4 else 0}, "kitNumber": 0}
+            for index in range(23)
+        ]
+        store.save_squad({"id": empty_id, "formation": "f442", "players": short_players}, requested_id=empty_id)
+        store.set_active_squad(empty_id)
+        filled = [value for value in item_ids(squad_by_id(store, empty_id)) if value > 0]
+        if len(filled) != 4:
+            fail(f"a user-built squad was auto-filled with unrequested players: {len(filled)} slots")
+        reopened_short = BetaIdentityStore(str(db), "existing")
+        filled = [value for value in item_ids(squad_by_id(reopened_short, empty_id)) if value > 0]
+        if len(filled) != 4:
+            fail(f"reopening the store auto-filled a user-built squad: {len(filled)} slots")
+        store = reopened_short
+        store.set_active_squad(second_id)
+
+        # 1f. Deleting a squad removes it for good: the editor's stale write for
+        #     that id must not bring it back.
         store.delete_squad(empty_id)
+        if any(int(row["id"]) == empty_id for row in store.squad_list()["squadList"]):
+            fail("delete_squad left the squad in the list")
+        store.save_squad(
+            {"id": empty_id, "squadName": "local", "formation": "f442", "players": short_players},
+            requested_id=empty_id,
+        )
+        if any(int(row["id"]) == empty_id for row in store.squad_list()["squadList"]):
+            fail("a stale editor write resurrected a deleted squad")
         store.delete_squad(copy_id)
         if len(store.squad_list()["squadList"]) != 2:
             fail("failed to return to the two-squad fixture")
@@ -207,6 +246,21 @@ def main() -> int:
         reopened = store.squad_list()["squadList"]
         if len(reopened) != 2 or int(store.squad_list_compact()["activeSquadId"]) != first_id:
             fail(f"multi-squad state did not survive a store reopen: {[s['id'] for s in reopened]}")
+
+        # 4b. FIFA 14 deletes a squad with GET /ut/delete/game/fifa14/squad/{id};
+        #     it has no DELETE verb.  Before this was routed, the request fell
+        #     through to the generic unmapped-route ack, so the client was told
+        #     the delete succeeded while the squad stayed in the list.
+        if HttpProbe._fut_squad_delete_id("/ut/delete/game/fifa14/squad/4") != 4:
+            fail("the tunnelled squad delete route is not recognized")
+        if HttpProbe._fut_squad_delete_id("/ut/delete/game/fifa14/squad/4?_=17") != 4:
+            fail("a query string must not hide the tunnelled squad delete")
+        for benign in (
+            "/ut/game/fifa14/squad/4", "/ut/delete/auth", "/ut/delete/game/fifa14/squad",
+            "/ut/delete/game/fifa14/squad/", "/ut/game/fifa14/squad/list",
+        ):
+            if HttpProbe._fut_squad_delete_id(benign) is not None:
+                fail(f"{benign} must not be treated as a squad delete")
 
         # 5. Deleting a squad frees its cards without destroying them, and the
         #    final remaining squad cannot be deleted.


### PR DESCRIPTION
## Summary

Adds support for more than one FUT squad per club, and stops a squad the user has not finished filling from being silently populated with arbitrary owned players.

The persistent schema was always keyed by `squad_id`; the single-squad limit lived entirely in the server logic around it. Every squad request contract in this PR was taken from a local probe capture of the retail FIFA 14 squad hub, not guessed.

## Problems fixed

1. **Only one squad could exist.** Creating a squad in-game overwrote the club's existing squad, including its name and formation.
2. **A partially filled squad was auto-populated.** Selecting a squad with fewer than 11 players caused the server to wipe its slots and refill all 23 from whatever the club owned.
3. **Deleting a squad did nothing.** The squad was acknowledged as deleted but stayed in the list, and reappeared on the next refresh.
4. **Squad renames reverted.** A rename persisted only until the editor closed, after which the squad reverted to `Local XI`.

## Root causes

- `save_squad()` resolved every write to `fut_users.active_squad_id`, so a create request landed on the existing squad.
- `save_squad()` force-activated whatever it wrote and demoted every player outside that one squad back to My Club, which collapsed multi-squad state on each save.
- `_repair_active_squad_locked()` rebuilds an active squad holding fewer than 11 players from owned items. That recovery exists for a client-zeroed squad, but it cannot tell a corrupted squad from one the user is still building.
- `GET /ut/delete/game/fifa14/squad/{id}` was unrouted and fell through to the generic unmapped-route acknowledgement. FIFA 14 has no `DELETE` verb and tunnels squad deletion through this `/ut/delete/` path prefix, the same way it tunnels logout through `/ut/delete/auth`.
- Squad metadata was treated as mandatory-with-a-default. The editor's closing write carries all 23 slots and the formation but no `squadName`, so `"Local XI"` was stamped over the user's name on every save. `chemistry` and `starRating` had the same defect.

## Client contract confirmed from captures

| Action | Request |
| --- | --- |
| Create squad (empty or a copy) | `POST /ut/game/fifa14/squad`, no path id, body `id: 0` |
| Save/edit squad | `PUT /ut/game/fifa14/squad/{id}`, 23 slots, **no** `squadName` |
| Rename squad | `PUT /ut/game/fifa14/squad/{id}`, body `{id, squadName}` only |
| Delete squad | `GET /ut/delete/game/fifa14/squad/{id}` |

## Changes

**`server/local_identity.py`**

- `create_squad()` handles `POST /squad` with a zero id. The new squad is deliberately **not** selected, so creating one cannot swap the match squad for an empty XI.
- `_document_squad_id()` resolves a write's target from the path id or the body's `squadId`/`id`.
- `_set_active_squad_locked()` keeps exactly one active squad and never leaves the persona with none. An explicit `active: false` no longer steals the user's selection; a body without the member keeps the previous select-on-save behaviour.
- `_sync_player_piles_locked()` marks a card `squad` when **any** squad fields it, replacing the per-write check that demoted other squads' members.
- `update_squad_metadata()` applies players-less writes (name, formation, chemistry, rating). A body carrying only captain/kicktakers still writes nothing, preserving the tournament handoff.
- Squad metadata is now optional on save: an absent member keeps its stored value instead of reverting to a default.
- `delete_squad()` removes a squad without destroying cards — freed players return to My Club. The last remaining squad is refused, since the match flows always need an active squad document.
- A write naming a squad id the persona does not own is ignored rather than creating one, so a stale editor write cannot resurrect a squad that was just deleted. Creation remains as a bootstrap safety net for a persona that owns no squad at all.
- New `client_saved` column on `squads`, migrated in place alongside the existing `chemistry`/`star_rating` migrations — no club, player, pack or economy state is reset. `_repair_active_squad_locked()` skips squads carrying it, so a user-built squad is never auto-populated. Legacy rows default to `0` and keep the existing recovery behaviour.

**`server/probe.py`**

- `HttpProbe._fut_squad_delete_id()` recognizes the tunnelled delete route, tolerating a query string and rejecting `/ut/delete/auth`, the id-less path and the ordinary squad path.
- Routes squad delete, `DELETE /squad/{id}`, and `PUT|POST /squad/active/{id}`. The delete answers with the same empty document the route already returned; the client re-reads `/squad/list` immediately afterwards, so no new response contract is invented.
- `POST /squad` with a zero id routes to `create_squad`; other writes echo back the squad that was written rather than whichever is active.
- Emits `fut-squad-created` and `fut-squad-deleted` for traceability.

**`server/beta_identity.py`**

- Scoped an unscoped `DELETE FROM squad_players` to the persona's own squads.

**`tools/verify_fifa14_multi_squad.py`** (new) — replays the captured request shapes: zero-id create (empty and copy), rename, captain-only handoff, the editor's nameless closing write, per-squad detail, active selection in both directions, cross-squad pile retention, no auto-fill of a user-built squad across a store reopen, delete-frees-cards-without-destroying-them, last-squad-undeletable, no resurrection from a stale write, and delete-route recognition.

**`tools/summarize_fifa14_squad_requests.py`** (new) — decodes the probe capture and reports which squad ids the client addressed, the bodies it sent and the persisted squad state, so an in-game squad action that does nothing can be told apart from a server that refused the write.

## Testing

Repository check from `CONTRIBUTING.md`:

```
python -m compileall -q server tools     # exit 0
```

Verifier suites, all exit 0:

```
python tools\verify_fifa14_multi_squad.py
python tools\verify_fifa14_beta2.py
python tools\verify_fifa14_consumables_beta224.py
python tools\verify_fifa14_market_beta2250.py
python tools\verify_fifa14_postmatch_beta2256.py
python tools\verify_fifa14_postmatch_beta2259.py
python tools\verify_fifa14_regressions_beta2258.py
python tools\verify_fifa14_pack_ui_performance_beta2250.py
```

`tools\verify_fifa14_pack_ui_performance_beta2244.py` fails on a pinned SHA-256 of `server/pack-weights.v237.json`. This is pre-existing and unrelated: it fails identically on a clean checkout of `main`, and no file it hashes is touched by this PR.

Runtime test, through `RUN_FIFA14_LOCAL_BETA.cmd` against the retail FIFA 14 client:

- Created several squads from the squad hub, both empty and as copies of an existing squad. Each persisted as a separate squad with its own name and formation.
- Named a squad, left the editor and re-entered it: the name persisted instead of reverting to `Local XI`.
- Left a squad partially filled and selected it: it kept exactly the players chosen and was not padded with other owned cards.
- Deleted a squad: it left the squad list and stayed deleted after finishing a match and after restarting the client.
- The client remained connected to FUT throughout; squad, club and economy state persisted across the restart.

## Notes for reviewers

- The `squads.client_saved` migration is additive and runs in place. Existing clubs keep their squad, players, packs and economy.
- Deleting the currently active squad promotes the lowest remaining squad id.
- The sparse-write guard is unchanged: a save that drops an existing squad below `MIN_RECOGNIZED_SQUAD_PLAYERS` recognized players is still treated as the transient parser state it was written for, so a full squad cannot be cut to a very short one in a single edit.
- No generated artifacts, certificates, logs, virtual environments, local club state or game files are included; the diff is limited to three server modules and two new tools.
