### PR TITLE
feat: Add FUT Workshop editor for custom player cards

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -1,0 +1,240 @@
+# FIFA 14 Local FUT API Specification
+
+This file describes the practical API surface exposed by the local FUT server.
+
+The server is not a normal REST API in the sense of a framework router. It is a route-dispatching HTTP layer in `server/probe.py` that calls methods on the active identity store instance (`LocalIdentityStore` or `BetaIdentityStore`).
+
+---
+
+## 1. Runtime mode selection
+
+The mode is selected in the `main()` function of `server/probe.py`.
+
+### Startup flags
+
+- `--beta-mode`
+  - If present, the server uses `BetaIdentityStore`.
+  - Otherwise it uses `LocalIdentityStore`.
+
+- `--fut-account-mode`
+  - Choices: `new` or `existing`
+  - This affects the initial identity state and whether the account is treated as first-use or returning-user.
+
+The exact selection is here:
+
+- `server/probe.py` in `main()`
+
+Code path:
+
+```python
+identity_store = (
+    BetaIdentityStore(str(identity_db), args.fut_account_mode)
+    if args.beta_mode
+    else LocalIdentityStore(identity_db, args.fut_account_mode)
+)
+```
+
+Then the instance is assigned to the HTTP and Blaze servers:
+
+```python
+fut_http.identity_store = identity_store
+main_blaze.identity_store = identity_store
+```
+
+So the effective “local” or “beta” progression mode is not a string value stored in a config file. It is selected at process startup and carried through as an object instance.
+
+---
+
+## 2. Route-to-function mapping
+
+There is no separate route registry file. The mapping is implemented as a long `if/elif` chain inside `HttpProbe._handle()` in `server/probe.py`.
+
+The pattern is:
+
+1. read `path_without_query = self.path.partition("?")[0]`
+2. compare it against known route strings
+3. call methods on the current `identity_store`
+4. send the result back as JSON/XML
+
+### Example mappings
+
+| HTTP route | Method | Identity method called |
+| --- | --- | --- |
+| `/ut/auth` | POST/GET | `start_session()` |
+| `/ut/game/fifa14/user/accountinfo` | GET | `account_info()` |
+| `/ut/game/fifa14/phishing` | GET | `phishing_question()` |
+| `/ut/game/fifa14/phishing/validate` | POST | `validate_phishing_answer()` |
+| `/ut/game/fifa14/user` | GET/POST | `ensure_fut_user()` / `update_club_profile()` |
+| `/ut/game/fifa14/user/action` | GET | `user_actions()` |
+| `/ut/game/fifa14/user/action/{name}` | POST/DELETE | `update_user_action()` |
+| `/ut/game/fifa14/item` | GET/POST/DELETE | `club_items()`, `move_items()`, `quick_sell()` |
+| `/ut/game/fifa14/squad` | GET/POST | `squad_list()`, `save_squad()` |
+| `/ut/game/fifa14/transfermarket` | GET | `market_search()` |
+| `/ut/game/fifa14/trade` | POST | `list_for_sale()` |
+| `/ut/game/fifa14/purchased/items` | POST | `purchase_pack()` |
+| `/ut/game/fifa14/club` | GET/POST | `club_items()`, `update_club_profile()` |
+| `/ut/game/fifa14/...` | various | whichever branch in `_handle()` matches |
+
+The actual route dispatch is all in a single file:
+
+- `server/probe.py` → `HttpProbe._handle()`
+
+This is the main “path to function” map.
+
+---
+
+## 3. Identity store responsibilities
+
+### `LocalIdentityStore`
+
+Defined in `server/local_identity.py`.
+
+This is the base persistence layer for progress, club, squad, items, market, and user actions.
+
+Key methods include:
+
+- `account_info()`
+- `start_session()`
+- `ensure_fut_user()`
+- `user_actions()`
+- `update_user_action()`
+- `phishing_question()`
+- `validate_phishing_answer()`
+- `purchase_pack()`
+- `club_items()`
+- `save_squad()`
+- `market_search()`
+- `trade_pile()`
+- `list_for_sale()`
+- `quick_sell()`
+- `view_items()`
+- `move_items()`
+- `apply_consumable()`
+
+### `BetaIdentityStore`
+
+Defined in `server/beta_identity.py`.
+
+This inherits from `LocalIdentityStore` and adds richer progression logic, such as:
+
+- offline seasons
+- tournaments
+- match settlement
+- coin wallet logic
+- beta-only progression state
+
+It is selected when `--beta-mode` is active.
+
+---
+
+## 4. Database location and persistence
+
+The default SQLite database path is set in the `main()` function of `server/probe.py`.
+
+```python
+identity_db = (
+    Path(args.identity_db).resolve()
+    if args.identity_db
+    else (SERVER_DIRECTORY.parent / "artifacts" / "local-fut.sqlite3")
+)
+```
+
+So the default location is:
+
+- repo root / `artifacts` / `local-fut.sqlite3`
+
+On this machine that resolves to:
+
+- `c:\Users\Madatek\source\repos\f14local\FIFA-14-Local-FUT\artifacts\local-fut.sqlite3`
+
+This is created at runtime because the IdentityStore constructor calls:
+
+```python
+self.database.parent.mkdir(parents=True, exist_ok=True)
+```
+
+and then opens SQLite with:
+
+```python
+sqlite3.connect(self.database, timeout=10)
+```
+
+The database holds the actual progression state, including:
+
+- identity and session records
+- club data
+- FUT user state
+- squad records
+- item inventory
+- pack records
+- market listings
+- client data blobs
+- user actions
+
+### Important note
+
+If you start the server without passing `--identity-db`, it will use the default path above. If you specify a custom path, it will use that instead.
+
+---
+
+## 5. Request/response conventions
+
+### HTTP responses
+
+Most FUT responses are JSON and are built via:
+
+```python
+build_fut_json_payload(document)
+```
+
+This serializes Python dicts as compact JSON with a trailing newline.
+
+### Content type
+
+The common response pattern is:
+
+```python
+self.send_header("content-type", "application/json; charset=utf-8")
+self.send_header("cache-control", "no-store")
+```
+
+### Structured logging
+
+All substantive traffic is logged through:
+
+```python
+def emit(kind: str, **fields) -> None:
+    print(json.dumps({"time": ..., "kind": kind, **fields}), flush=True)
+```
+
+This gives debugging output such as:
+
+- `http-probe`
+- `blaze-request`
+- `blaze-response`
+- `fut-http-response`
+- `fut-squad-state-beta222`
+- `fut-purchased-items-pack-purchased`
+
+---
+
+## 6. Typical server lifecycle
+
+1. `main()` sets up listeners and chooses an identity store.
+2. `BlazeProbe` handles login/bootstrap traffic.
+3. `HttpProbe` handles FUT HTTP routes.
+4. `LocalIdentityStore` or `BetaIdentityStore` persists state to SQLite.
+5. The client requests more data, and the server responds from database-backed state.
+
+---
+
+## 7. Useful entry points
+
+If you are tracing a route, start here:
+
+- `server/probe.py` → `main()`
+- `server/probe.py` → `HttpProbe._handle()`
+- `server/local_identity.py` → `LocalIdentityStore`
+- `server/beta_identity.py` → `BetaIdentityStore`
+
+These are the primary places where state, routing, and persistence intersect.

--- a/CUSTOM_CARDS.md
+++ b/CUSTOM_CARDS.md
@@ -1,0 +1,305 @@
+# Custom Cards: Workflow and Implementation Notes
+
+## Purpose
+
+The custom-card feature creates FIFA 14 FUT card variants for verified base-game players. A card keeps the original player identity while allowing local edits to the rating, rarity, six face attributes, detailed gameplay attributes, and player traits.
+
+This feature is experimental. The local editor and persistence path work, but the FIFA 14 client does not yet render every edited gameplay value exactly as entered. This document is a handoff guide for reproducing the feature and investigating the remaining client-side mapping issue.
+
+## User workflow
+
+### Prerequisites
+
+- A working FIFA 14 Local FUT checkout.
+- The repository virtual environment at `.venv`.
+- A local FIFA 14 installation configured through the normal launcher.
+
+The player-data cache is generated from the installed FIFA 14 `cards_ng_db` data by the normal launcher when it is missing. An existing cache is preserved and reused. The editor refuses to operate when the cache is missing, invalid, or cannot be generated.
+
+### Start the server and editor
+
+1. Start the local runtime with `RUN_FIFA14_LOCAL_BETA.cmd`.
+2. On first launch, wait for the launcher message that it generated `artifacts/fifa14-player-data-v1.json` from the installed game database. Later launches report that the existing cache is being reused.
+3. Wait until the local FUT HTTP server is ready.
+4. Open `http://127.0.0.1:8099/local-editor/` in a browser.
+5. Search for a verified player.
+6. Select the player and edit the card fields.
+7. Keep **Grant to My Club** enabled when saving a new card, or use **Grant** beside an existing saved card.
+8. Restarting the server is not required between editor changes, but it is useful when testing a new server build.
+9. After a code change, grant the card again. Granting rebuilds the stored My Club ItemData payload.
+
+Existing saved cards can be reused. Creating a new card is only necessary when testing a different version or wanting to preserve an earlier card unchanged.
+
+### Recommended test card
+
+For a clear mapping test, use a player whose base values are visibly different from the requested values. Set:
+
+- Overall: `99`
+- All six face attributes: `99`
+- All gameplay attributes: `99`
+- Weak foot: `5`
+- Skill moves: `4`
+- Preferred foot: opposite of the base player
+- Attacking work rate: `High` (`2`)
+- Defensive work rate: `Low` (`0`)
+
+Record the player's original values before editing. In-game, inspect all four pages:
+
+- Player Information
+- Physical Attributes
+- Mental Attributes
+- Skill Attributes
+
+Do not use only the overall rating as proof that gameplay mapping worked. The rating and face values can change even when detailed fields are mapped incorrectly.
+
+## Editor/API workflow
+
+The editor assets are served by `server/probe.py` and live in `server/editor/`.
+
+### Browser routes
+
+| Method | Route | Purpose |
+| --- | --- | --- |
+| GET | `/local-editor/` | Editor page |
+| GET | `/local-editor/api/players?q=...` | Search verified editable players |
+| GET | `/local-editor/api/cards` | List saved cards |
+| GET | `/local-editor/api/cards/export` | Export the custom-card catalog |
+| POST | `/local-editor/api/cards` | Create a card; optional `grant: true` |
+| PUT | `/local-editor/api/cards/{cardId}` | Update a card; optional `grant: true` |
+| POST | `/local-editor/api/cards/{cardId}/grant` | Rebuild/grant the card to My Club |
+| DELETE | `/local-editor/api/cards/{cardId}` | Delete a saved definition |
+| POST | `/local-editor/api/cards/import` | Import a catalog document |
+
+The request and response bodies are JSON. Errors are returned as HTTP 400 JSON objects with an `error` field.
+
+### Editor serialization
+
+`server/editor/app.js` defines the fields and sends this shape:
+
+```json
+{
+  "assetId": 158023,
+  "rating": 99,
+  "rareFlag": 3,
+  "teamId": 1,
+  "leagueId": 1,
+  "attributes": [99, 99, 99, 99, 99, 99],
+  "gameplayAttributes": {
+    "acceleration": 99,
+    "sprintspeed": 99,
+    "positioning": 99,
+    "finishing": 99,
+    "shotpower": 99,
+    "longshots": 99,
+    "volleys": 99,
+    "penalties": 99,
+    "vision": 99,
+    "crossing": 99,
+    "freekickaccuracy": 99,
+    "shortpassing": 99,
+    "longpassing": 99,
+    "curve": 99,
+    "agility": 99,
+    "balance": 99,
+    "reactions": 99,
+    "ballcontrol": 99,
+    "dribbling": 99,
+    "interceptions": 99,
+    "headingaccuracy": 99,
+    "marking": 99,
+    "standingtackle": 99,
+    "slidingtackle": 99,
+    "jumping": 99,
+    "stamina": 99,
+    "strength": 99,
+    "aggression": 99,
+    "gkdiving": 99,
+    "gkhandling": 99,
+    "gkkicking": 99,
+    "gkreflexes": 99,
+    "gkpositioning": 99
+  },
+  "traits": {
+    "weakfootabilitytypecode": 5,
+    "skillmoves": 4,
+    "preferredfoot": 2,
+    "attackingworkrate": 2,
+    "defensiveworkrate": 0
+  }
+}
+```
+
+Skill moves being limited to `0` through `4` is intentional. The FIFA 14 `cards_ng_db` descriptor defines `skillmoves` as `0..4`. The other relevant ranges are gameplay attributes `1..99`, weak foot `1..5`, preferred foot `1..2`, and work rates `0..2`.
+
+## Code path
+
+### 1. Player-data cache
+
+`tools/extract_fifa14_player_data.py` reads verified player rows from the installed game database and writes `artifacts/fifa14-player-data-v1.json`. `tools/launch_fifa14_hub_store.ps1` invokes it automatically when the output file does not exist, using the resolved FIFA 14 `Game` directory and the project virtual-environment Python interpreter. The launcher does not overwrite an existing cache.
+
+`server/player_data.py` validates that cache. It defines:
+
+- `GAMEPLAY_FIELDS`: the 33 named gameplay fields used by the editor.
+- `TRAIT_RANGES`: the five editable trait fields and their valid ranges.
+
+`server/local_identity.py` merges the detailed cache data into `EDITOR_PLAYER_BY_ASSET`. The editor only searches this verified set.
+
+### 2. Catalog validation and persistence
+
+`server/custom_cards.py` owns the saved custom-card catalog.
+
+The catalog is stored beside the identity database as:
+
+```text
+custom-cards.v1.json
+```
+
+The catalog validates:
+
+- `assetId` exists in the verified base-player set.
+- Exactly six face attributes are supplied.
+- Gameplay fields are integers from `1` to `99`.
+- Trait values obey `TRAIT_RANGES`.
+- Custom versions are between `50` and `99`.
+- A player/version pair is not duplicated.
+
+The saved definition receives:
+
+- `resourceId = resource_id_for(assetId, version)`
+- `definitionId = assetId`
+- `specialCard = true`
+- `cardType = custom`
+
+The resource/definition regression is covered by `tests/test_custom_cards.py`.
+
+### 3. Grant and ItemData construction
+
+`LocalIdentityStore.grant_custom_card()` in `server/local_identity.py`:
+
+1. Loads the saved card definition.
+2. Allocates or reuses an item ID in the `196000000000` custom-card range.
+3. Adds normal My Club state such as contract, fitness, morale, and pile.
+4. Calls `_canonical_player_payload()`.
+5. Stores the resulting JSON in the `items` SQLite table.
+6. Records the card-to-item relationship in `custom_card_grants`.
+
+Granting an existing card reuses its item ID and replaces the stored payload. This is the required operation after changing the server code.
+
+### 4. Canonical payload
+
+`_canonical_player_payload()` creates the game-facing ItemData object. It currently emits:
+
+- `assetId`, `resourceId`, and `definitionId`.
+- `rating`, `preferredPosition`, team, league, nation, rarity, and player identity fields.
+- `attributeList` and `attributeArray` for the six face attributes.
+- `statsList` and `statsArray` for the separate five-value lifetime/stat counter structure.
+- Flat gameplay and trait keys, such as `acceleration`, `finishing`, `preferredfoot`, and `defensiveworkrate`.
+- Nested `gameplayAttributes` and `traits` metadata for local persistence/editor use.
+
+The implementation currently places the flat gameplay and trait overrides in the early/native portion of the JSON object, before compatibility aliases. It also retains nested copies at the end of the payload.
+
+Important: the unit tests prove that these values survive Python canonicalization and SQLite persistence. They do not prove that the FIFA client consumes every flat key as an ItemData override.
+
+## Current known issue
+
+The feature remains partially functional in-game:
+
+- Card identity and overall rating change.
+- Six face attributes can change.
+- Preferred foot has been observed changing correctly.
+- Gameplay pages show values that are changed, but not necessarily the values entered in the editor.
+- Weak foot, skill moves, and defensive work rate have not consistently matched the editor input.
+- Some values appear too high while others appear too low.
+
+This does not currently look like integer overflow. The descriptor confirms the relevant numeric ranges, and values remain ordinary small integers in the exported catalog and canonical Python payload.
+
+The unresolved question is the native FIFA 14 ItemData representation. The project currently sends long field names such as `acceleration` and `defensiveworkrate`. The installed `cards_ng_db` descriptor also defines short names, for example:
+
+```text
+acceleration          SPge
+sprintspeed           NrcP
+attackingworkrate     BqFe
+defensiveworkrate     boFm
+skillmoves            BAPc
+weakfootability...    aOBn
+```
+
+Those short names belong to the database descriptor and are a strong lead, but they have not yet been proven to be valid keys in the FUT ItemData response. Do not assume that adding short keys is correct without comparing them to a captured retail ItemData payload or testing against a disposable card.
+
+A second lead is array mapping. `attributeArray` is known to contain six face values, while `statsList` is currently treated as a five-value counter array. No verified conversion currently exists from the 33 named gameplay fields into an ordered native ItemData array. A collaborator should confirm whether the client expects named fields, short-name fields, a packed bitfield, or static database data combined with item-level overrides.
+
+## Reproduction and evidence collection
+
+For every test, save three artifacts:
+
+1. The exported catalog from `/local-editor/api/cards/export`.
+2. The exact stored item payload from the SQLite `items.payload` row for the granted item.
+3. Screenshots or a written table of the four in-game attribute pages.
+
+The comparison table should contain:
+
+| Field | Editor input | Export JSON | SQLite ItemData | In-game value |
+| --- | ---: | ---: | ---: | ---: |
+| acceleration | 99 | 99 | 99 | ? |
+| finishing | 99 | 99 | 99 | ? |
+| defensiveworkrate | 0 | 0 | 0 | ? |
+| skillmoves | 4 | 4 | 4 | ? |
+| preferredfoot | 2 | 2 | 2 | ? |
+
+Use a fresh item grant after each payload-format experiment. FIFA may cache an item or retain an older payload in the local client session.
+
+To inspect the SQLite payload, first identify the active identity database path from the launcher configuration or runtime logs, then query the custom item range. Do not include personal paths, credentials, or unrelated account data in a public issue.
+
+## Tests
+
+The focused test command is:
+
+```powershell
+$env:PYTHONPATH = "server"
+.\.venv\Scripts\python.exe -m unittest tests.test_custom_cards -q
+```
+
+The full repository test command is:
+
+```powershell
+$env:PYTHONPATH = "server"
+.\.venv\Scripts\python.exe -m unittest discover -s tests -q
+```
+
+The current tests verify:
+
+- Versioned custom-card resource identity.
+- Retention of gameplay and trait dictionaries during canonicalization.
+- Presence and ordering of flat override keys in the generated Python payload.
+
+They do not launch FIFA or validate client rendering. A future regression test should compare a captured/certified native ItemData payload with the client-visible values.
+
+## Collaboration request
+
+A useful issue or pull request should include:
+
+- FIFA 14 build and platform.
+- Local FUT branch/commit.
+- Whether the card was newly created or re-granted after the server restart.
+- The exported card JSON with unrelated identity data removed if necessary.
+- The stored SQLite ItemData payload for the same item.
+- The base player asset ID and original values.
+- A table mapping editor value to in-game value.
+- Screenshots of Player Information, Physical, Mental, and Skill pages.
+- Whether the client was restarted between tests.
+
+The main question for collaborators is:
+
+> Which exact ItemData fields or encoded structure does FIFA 14 PC read for gameplay attributes and traits on a versioned FUT player item, and how do those fields map to the `cards_ng_db` descriptor names?
+
+## Files involved
+
+- `server/editor/index.html`: editor controls and valid HTML input ranges.
+- `server/editor/app.js`: browser serialization and API calls.
+- `server/probe.py`: local editor HTTP routes.
+- `server/custom_cards.py`: validation and catalog persistence.
+- `server/player_data.py`: gameplay field names and trait ranges.
+- `server/local_identity.py`: grant flow, SQLite persistence, and canonical ItemData construction.
+- `tools/extract_fifa14_player_data.py`: installed-game database extraction.
+- `artifacts/cards-ng-db-descriptor/cards_ng_db-meta.manifest.json`: extracted database field names, short names, and ranges.
+- `tests/test_custom_cards.py`: current regression coverage.

--- a/SERVER_ARCHITECTURE.md
+++ b/SERVER_ARCHITECTURE.md
@@ -1,0 +1,290 @@
+# FIFA 14 Local FUT Server Architecture
+
+This document is a working reference for how the local FIFA 14 FUT server is structured and what each part is responsible for.
+
+## 1. Purpose
+
+This project does not run a real EA backend. Instead, it creates a localhost compatibility layer that mimics the protocols and HTTP routes FIFA 14 expects during startup and gameplay.
+
+The server is designed to:
+
+- answer FIFA 14 startup/bootstrap traffic;
+- present a believable FUT login/session flow;
+- serve synthetic but structurally valid HTTP JSON/XML responses;
+- persist local user state in SQLite so a fresh account can evolve across sessions;
+- provide a stable local development/debug target for FUT reverse engineering.
+
+The implementation lives primarily in:
+
+- `server/probe.py`
+- `server/local_identity.py`
+- `server/beta_identity.py`
+
+---
+
+## 2. High-level runtime model
+
+At startup, `server/probe.py` builds multiple listeners in parallel:
+
+- redirector on TCP port `42127` (or TLS redirector mode)
+- main Blaze listener on TCP port `42128`
+- bootstrap HTTP server on port `8080`
+- FUT HTTP server on port `8099`
+- optional dynamic HTTP listener and optional LSX/GOSCA listeners
+
+The `main()` function in `probe.py` creates the server instances, attaches the persistence layer, starts each `serve_forever()` thread, and then blocks while the process stays alive.
+
+The important idea is that the process is a protocol shim, not a full game server. It exposes the exact ports and shapes FIFA 14 expects, then returns controlled synthetic payloads.
+
+---
+
+## 3. Main server components
+
+### 3.1 `BlazeProbe`
+
+This is the most important network listener for the login/bootstrap path.
+
+It handles raw Blaze packets, parses headers, and responds to component/command combinations that FIFA 14 sends during login and config fetches. Important behaviors include:
+
+- `OriginLogin` handling (`component == 1`, command `0x98`)
+- `PreAuth` response (`component == 9`, command `7`)
+- `FetchConfig` response (`component == 9`, command `1`)
+- `Ping` and `PostAuth` responses
+- fake login notifications such as user-authenticated / user-added / user-extended-data
+- game reporting completion handling for match result notifications
+
+This is where the fake “EA-style” network semantics are implemented. The server tries to produce valid Blaze TDF response bodies and match the expected retail schema as closely as possible.
+
+### 3.2 `HttpProbe`
+
+This is the HTTP compatibility layer used by FIFA 14 FUT routes.
+
+It handles:
+
+- local bootstrap XML like `/futBoot.xml`
+- FUT localization XML (`/fut/loc/...`)
+- dynamic messages endpoints
+- FUT player metadata endpoints
+- Icebreaker pack list fixtures
+- `/ut/auth`
+- `/ut/game/fifa14/...` account, club, item, squad, market, trade, pack, and tournaments endpoints
+- debug endpoints like `/__fifa14_local_fut_health`
+
+The handler is a giant route dispatcher. It inspects:
+
+- path
+- HTTP method
+- query string
+- request body
+- identity store state
+
+Then it returns a JSON/XML payload from either:
+
+- a fixed synthetic document,
+- a generated local identity response,
+- or a database-backed stateful response.
+
+### 3.3 `TcpProbe` and `TlsTcpProbe`
+
+These are lower-level probe listeners used for connection and TLS diagnostics.
+
+- `TcpProbe` reads raw bytes and identifies whether a payload looks like TLS or a Blaze frame.
+- `TlsTcpProbe` wraps sockets in an SSL context and can act as a redirector/proxy-like endpoint for compatibility testing.
+
+These are mainly used to observe what FIFA 14 tries to connect to and to reproduce old EA compatibility quirks.
+
+### 3.4 `GoscaProbe`
+
+This is a specialized listener for GOSca certificate/redirector behavior. It returns a certificate payload shaped like an EA-style XML response when enabled.
+
+---
+
+## 4. Identity and persistence model
+
+### 4.1 `LocalIdentityStore`
+
+`server/local_identity.py` defines the SQLite-backed persistence layer.
+
+It creates tables such as:
+
+- `identity`
+- `sessions`
+- `clubs`
+- `fut_users`
+- `squads`
+- `squad_players`
+- `items`
+- `consumable_effects`
+
+This store is responsible for:
+
+- account/session creation
+- user profile data
+- club data and coins
+- squad list and squad membership
+- item collections, quick-sell, moves, activation
+- consumable usage
+- marketplace/trade state
+- pack purchases and reward fulfillment
+
+The state is stored in a SQLite database, with a default path under:
+
+- `artifacts/local-fut.sqlite3`
+
+This makes the server stateful across launches instead of a completely ephemeral mock.
+
+### 4.2 `BetaIdentityStore`
+
+`server/beta_identity.py` extends the base identity store for the newer beta progression flow.
+
+It adds richer local FUT state for:
+
+- starter clubs
+- match assets and stadium data
+- offline seasons and tournaments
+- competition progression and rewards
+- wallet transactions
+- beta-specific match settlement behavior
+
+The `main()` function selects one of the two stores via:
+
+- `--beta-mode` to choose `BetaIdentityStore`
+- otherwise `LocalIdentityStore`
+
+---
+
+## 5. How a login flow works
+
+The server is designed to match the observed retail sequence.
+
+### Startup sequence
+
+1. FIFA 14 connects to the redirector/proxy listeners.
+2. The redirector or TLS probe detects the requested server or redirector flow.
+3. FIFA 14 sends Blaze requests like `OriginLogin`, `PreAuth`, and `FetchConfig`.
+4. `BlazeProbe` answers with synthetic but valid records.
+5. The client then requests FUT HTTP endpoints like `/ut/auth` and `/ut/game/fifa14/user/accountinfo`.
+6. The `HttpProbe` returns JSON bodies that describe a local account, local club, local settings, and onboarding state.
+
+### Identity initialization
+
+The `LocalIdentityStore` creates a fresh local persona when the account is in a first-use mode. It keeps a single stable local identity and can also create a returning-user state when a club already exists.
+
+The account payload is produced through helper functions such as:
+
+- `build_fut_account_info()`
+- `build_fut_auth_response()`
+- `build_fut_phishing_question()`
+- `build_fut_settings_response()`
+
+---
+
+## 6. How the HTTP routes work
+
+The HTTP server is effectively a route table plus a stateful backend.
+
+Common patterns:
+
+- `path_without_query` is extracted from `self.path`
+- a route match is tested with `if ... and path_without_query == "..."`
+- a response is generated either from a helper or from the identity store
+- the response is sent with JSON content type and a no-store cache header
+- the server emits a structured log event with `emit()`
+
+Examples of routes handled by the server:
+
+- `/ut/auth`
+- `/ut/game/fifa14/user/accountinfo`
+- `/ut/game/fifa14/phishing`
+- `/ut/game/fifa14/settings`
+- `/ut/game/fifa14/club`
+- `/ut/game/fifa14/item`
+- `/ut/game/fifa14/squad`
+- `/ut/game/fifa14/transfermarket`
+- `/ut/game/fifa14/trade`
+- `/ut/game/fifa14/purchased/items`
+- `/ut/game/fifa14/clubUser`
+- tournament and offline season endpoints
+
+The handler deliberately returns built-in synthetic data rather than failing 404s for most of the routes it has been proven to need.
+
+---
+
+## 7. Why it uses synthetic payloads instead of a true backend
+
+This project is built around compatibility and observation, not a full authenticated online service.
+
+The server tries to satisfy the client’s expectations by keeping the following true:
+
+- response structure matches the expected game contract;
+- IDs and nested fields look like real FUT data;
+- state persists across sessions;
+- the client can continue through onboarding, squads, packs, and market flows;
+- logs make failures discoverable.
+
+The server intentionally avoids pretending to be a real EA service. It is a local emulation/shim tuned to FIFA 14’s client-side expectations.
+
+---
+
+## 8. Logging and debugging
+
+The code uses a central `emit()` helper that prints JSON logs to stdout.
+
+This produces structured events like:
+
+- `started`
+- `http-probe`
+- `blaze-request`
+- `blaze-response`
+- `fut-http-response`
+- `fut-local-item-quicksell`
+- `fut-squad-state-beta222`
+- `fut-purchased-items-pack-purchased`
+
+This is one of the most useful debugging features in the repo. If something breaks in the client, the logs usually show the exact path, request body, response name, and state transition that occurred.
+
+---
+
+## 9. Typical request path during gameplay
+
+A normal local FUT session usually flows like this:
+
+1. client connects to redirector / Blaze listeners
+2. `OriginLogin` returns a session token and local persona info
+3. config fetch runs and sets FUT bootstrap URLs
+4. client calls `/ut/auth`
+5. client calls `/ut/game/fifa14/user/accountinfo`
+6. phishing and trusted-device flows resolve
+7. club/user info and stored actions load
+8. local club and squad are loaded
+9. store/pack routines, item operations, market, and tournament routes are served from the identity store
+10. all changes are persisted into SQLite
+
+---
+
+## 10. Important implementation notes
+
+- This server is intentionally local-only and uses loopback addresses.
+- It binds to specific ports and can enforce exclusive port ownership on Windows.
+- It creates temporary certificate chains when redirector TLS compatibility is required.
+- The project is tuned around observed FIFA 14 client behavior and reverse engineering data rather than a formal external spec.
+- It is designed for development, local testing, and compatibility experimentation.
+
+---
+
+## 11. Files to look at first when debugging
+
+If you need to understand or extend the server, read in this order:
+
+1. `server/probe.py` — runtime setup and all protocol/HTTP handlers
+2. `server/local_identity.py` — core persistent FUT identity and item logic
+3. `server/beta_identity.py` — beta progression and richer FUT simulation
+4. The generated SQLite DB under `artifacts/` — current persisted local state
+
+---
+
+## 12. Summary
+
+The server is a local FIFA 14 compatibility runtime that intentionally fakes the requirements of the game’s network protocol and HTTP REST layer. It is not a generic web API; it is a reverse-engineered, stateful compatibility server built to satisfy FIFA 14’s expectations and persist local FUT state for experimentation and debugging.
+
+If you are extending the project, start from the port setup in `main()`, then follow the router logic in `HttpProbe._handle()` and the Blaze logic in `BlazeProbe.handle()`.

--- a/server/custom_cards.py
+++ b/server/custom_cards.py
@@ -1,0 +1,236 @@
+"""Portable custom-card definitions for variants of FIFA 14 base players."""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from fifa14_ids import resource_id_for
+from player_data import GAMEPLAY_FIELDS, TRAIT_RANGES
+
+
+SCHEMA = "fifa14-local-custom-cards-v1"
+MIN_CUSTOM_VERSION = 50
+MAX_CUSTOM_VERSION = 99
+ATTRIBUTE_COUNT = 6
+
+
+def _quality_for_rating(rating: int) -> str:
+    return "bronze" if rating <= 64 else "silver" if rating <= 74 else "gold"
+
+
+class CustomCardCatalog:
+    """Read/write local custom cards while preserving a real player identity."""
+
+    def __init__(self, path: Path | str, base_players: dict[int, dict[str, Any]]) -> None:
+        self.path = Path(path)
+        self.base_players = {int(asset_id): dict(player) for asset_id, player in base_players.items()}
+
+    def _load(self) -> dict[str, Any]:
+        if not self.path.is_file():
+            return {"schema": SCHEMA, "cards": []}
+        try:
+            document = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise ValueError(f"could not read custom card catalog: {error}") from error
+        if not isinstance(document, dict) or document.get("schema") != SCHEMA:
+            raise ValueError("unsupported custom card catalog schema")
+        cards = document.get("cards")
+        if not isinstance(cards, list):
+            raise ValueError("custom card catalog cards must be an array")
+        return document
+
+    def _write(self, document: dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        encoded = json.dumps(document, indent=2, ensure_ascii=False) + "\n"
+        handle, temporary = tempfile.mkstemp(prefix=self.path.name + ".", suffix=".tmp", dir=str(self.path.parent))
+        try:
+            with os.fdopen(handle, "w", encoding="utf-8", newline="\n") as output:
+                output.write(encoded)
+                output.flush()
+                os.fsync(output.fileno())
+            os.replace(temporary, self.path)
+        except Exception:
+            try:
+                os.unlink(temporary)
+            except OSError:
+                pass
+            raise
+
+    def _card_from_input(
+        self,
+        source: dict[str, Any],
+        *,
+        current_cards: list[dict[str, Any]],
+        card_id: str | None = None,
+        created_at: int | None = None,
+    ) -> dict[str, Any]:
+        try:
+            asset_id = int(source.get("assetId", source.get("baseAssetId")))
+        except (TypeError, ValueError) as error:
+            raise ValueError("base player assetId is required") from error
+        base = self.base_players.get(asset_id)
+        if base is None:
+            raise ValueError(f"assetId {asset_id} is not a base-game player")
+
+        def bounded(name: str, default: int, minimum: int, maximum: int) -> int:
+            try:
+                value = int(source.get(name, default))
+            except (TypeError, ValueError) as error:
+                raise ValueError(f"{name} must be an integer") from error
+            if not minimum <= value <= maximum:
+                raise ValueError(f"{name} must be between {minimum} and {maximum}")
+            return value
+
+        rating = bounded("rating", int(base.get("rating", 1)), 1, 99)
+        team_id = bounded("teamId", int(base.get("teamId", 0)), 1, 2_147_483_647)
+        league_id = bounded("leagueId", int(base.get("leagueId", 0)), 1, 2_147_483_647)
+        rare_flag = bounded("rareFlag", int(base.get("rareFlag", 0)), 0, 255)
+        raw_attributes = source.get("attributes", base.get("attributes", []))
+        if not isinstance(raw_attributes, list) or len(raw_attributes) != ATTRIBUTE_COUNT:
+            raise ValueError("attributes must contain exactly six values")
+        attributes: list[int] = []
+        for index, value in enumerate(raw_attributes):
+            try:
+                number = int(value)
+            except (TypeError, ValueError) as error:
+                raise ValueError(f"attributes[{index}] must be an integer") from error
+            if not 0 <= number <= 99:
+                raise ValueError(f"attributes[{index}] must be between 0 and 99")
+            attributes.append(number)
+
+        raw_gameplay = source.get("gameplayAttributes", base.get("gameplayAttributes"))
+        if not isinstance(raw_gameplay, dict):
+            raise ValueError("full player data is unavailable for this base player")
+        gameplay_attributes: dict[str, int] = {}
+        for field in GAMEPLAY_FIELDS:
+            try:
+                value = int(raw_gameplay[field])
+            except (KeyError, TypeError, ValueError) as error:
+                raise ValueError(f"gameplayAttributes.{field} must be an integer") from error
+            if not 1 <= value <= 99:
+                raise ValueError(f"gameplayAttributes.{field} must be between 1 and 99")
+            gameplay_attributes[field] = value
+        raw_traits = source.get("traits", base.get("traits"))
+        if not isinstance(raw_traits, dict):
+            raise ValueError("full player traits are unavailable for this base player")
+        traits: dict[str, int] = {}
+        for field, (minimum, maximum) in TRAIT_RANGES.items():
+            try:
+                value = int(raw_traits[field])
+            except (KeyError, TypeError, ValueError) as error:
+                raise ValueError(f"traits.{field} must be an integer") from error
+            if not minimum <= value <= maximum:
+                raise ValueError(f"traits.{field} must be between {minimum} and {maximum}")
+            traits[field] = value
+
+        requested_version = source.get("version")
+        if requested_version is None:
+            occupied = {
+                int(card.get("version", 0))
+                for card in current_cards
+                if int(card.get("assetId", 0)) == asset_id and card.get("cardId") != card_id
+            }
+            version = next((value for value in range(MIN_CUSTOM_VERSION, MAX_CUSTOM_VERSION + 1) if value not in occupied), None)
+            if version is None:
+                raise ValueError(f"assetId {asset_id} has no remaining custom card versions")
+        else:
+            version = bounded("version", MIN_CUSTOM_VERSION, MIN_CUSTOM_VERSION, MAX_CUSTOM_VERSION)
+            if any(
+                int(card.get("assetId", 0)) == asset_id
+                and int(card.get("version", 0)) == version
+                and card.get("cardId") != card_id
+                for card in current_cards
+            ):
+                raise ValueError(f"assetId {asset_id} version {version} is already in use")
+
+        now = int(time.time())
+        return {
+            "cardId": card_id or str(uuid.uuid4()),
+            "assetId": asset_id,
+            "resourceId": resource_id_for(asset_id, version),
+            "definitionId": asset_id,
+            "version": version,
+            "name": str(base.get("name", "")),
+            "commonName": str(base.get("commonName", base.get("name", ""))),
+            "position": str(base.get("position", "CM")).upper(),
+            "nation": int(base.get("nation", 0)),
+            "nationName": str(base.get("nationName", "")),
+            "rating": rating,
+            "teamId": team_id,
+            "leagueId": league_id,
+            "rareFlag": rare_flag,
+            "playStyle": int(base.get("playStyle", 0)),
+            "attributes": attributes,
+            "gameplayAttributes": gameplay_attributes,
+            "traits": traits,
+            "quality": _quality_for_rating(rating),
+            "cardType": "custom",
+            "specialCard": True,
+            "createdAt": int(created_at or now),
+            "updatedAt": now,
+        }
+
+    def list_cards(self) -> list[dict[str, Any]]:
+        document = self._load()
+        cards = [dict(card) for card in document["cards"] if isinstance(card, dict)]
+        return sorted(cards, key=lambda card: (str(card.get("name", "")).casefold(), str(card.get("cardId", ""))))
+
+    def get(self, card_id: str) -> dict[str, Any] | None:
+        return next((card for card in self.list_cards() if card.get("cardId") == card_id), None)
+
+    def save(self, source: dict[str, Any], card_id: str | None = None) -> dict[str, Any]:
+        document = self._load()
+        cards = [card for card in document["cards"] if isinstance(card, dict)]
+        existing = next((card for card in cards if card.get("cardId") == card_id), None)
+        if card_id is not None and existing is None:
+            raise ValueError("custom card does not exist")
+        card = self._card_from_input(
+            source,
+            current_cards=cards,
+            card_id=card_id,
+            created_at=None if existing is None else int(existing.get("createdAt", 0) or 0),
+        )
+        document["cards"] = [row for row in cards if row.get("cardId") != card_id] + [card]
+        self._write(document)
+        return card
+
+    def delete(self, card_id: str) -> bool:
+        document = self._load()
+        cards = [card for card in document["cards"] if isinstance(card, dict)]
+        retained = [card for card in cards if card.get("cardId") != card_id]
+        if len(retained) == len(cards):
+            return False
+        document["cards"] = retained
+        self._write(document)
+        return True
+
+    def export_document(self) -> dict[str, Any]:
+        return {"schema": SCHEMA, "cards": self.list_cards()}
+
+    def import_document(self, document: dict[str, Any], *, replace: bool = False) -> list[dict[str, Any]]:
+        if not isinstance(document, dict) or document.get("schema") != SCHEMA:
+            raise ValueError("unsupported custom card import schema")
+        incoming = document.get("cards")
+        if not isinstance(incoming, list):
+            raise ValueError("custom card import cards must be an array")
+        current = [] if replace else self.list_cards()
+        for raw_card in incoming:
+            if not isinstance(raw_card, dict):
+                raise ValueError("custom card import contains a non-object card")
+            card_id = str(raw_card.get("cardId") or uuid.uuid4())
+            existing = next((card for card in current if card.get("cardId") == card_id), None)
+            card = self._card_from_input(
+                raw_card,
+                current_cards=current,
+                card_id=card_id if existing is not None else None,
+                created_at=None if existing is None else int(existing.get("createdAt", 0) or 0),
+            )
+            card["cardId"] = card_id
+            current = [row for row in current if row.get("cardId") != card_id] + [card]
+        self._write({"schema": SCHEMA, "cards": current})
+        return self.list_cards()

--- a/server/editor/app.css
+++ b/server/editor/app.css
@@ -1,0 +1,50 @@
+:root {
+  --ink: #18201b;
+  --muted: #637167;
+  --paper: #f7f7ef;
+  --line: #cdd4c9;
+  --accent: #007d5a;
+  --accent-dark: #00583f;
+  --coral: #df6549;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; background: var(--paper); color: var(--ink); font-family: Georgia, "Times New Roman", serif; }
+button, input, select { font: inherit; }
+.topbar { min-height: 58px; display: flex; align-items: center; justify-content: space-between; padding: 0 5vw; border-bottom: 1px solid var(--line); background: #fffef8; }
+.brand { font-weight: 700; font-size: 1.2rem; letter-spacing: 0; }
+nav { display: flex; align-self: stretch; gap: 1.25rem; align-items: center; color: var(--muted); }
+nav a, nav span { text-decoration: none; color: inherit; padding: .2rem 0; }
+nav .active { color: var(--accent-dark); border-bottom: 3px solid var(--coral); font-weight: 700; }
+main { max-width: 1180px; margin: 0 auto; padding: 2rem 5vw 3rem; }
+.picker { border-bottom: 1px solid var(--line); padding-bottom: 1.5rem; }
+label, legend { display: block; font-size: .84rem; font-weight: 700; letter-spacing: 0; }
+.search-row { display: grid; grid-template-columns: minmax(200px, 2fr) minmax(180px, 1fr); gap: .75rem; margin-top: .45rem; }
+input, select { width: 100%; min-height: 38px; padding: .4rem .5rem; border: 1px solid #9eaba0; border-radius: 3px; background: #fff; color: var(--ink); }
+input:focus, select:focus { outline: 2px solid #69b698; outline-offset: 1px; }
+.workspace { display: grid; grid-template-columns: minmax(0, 2fr) minmax(250px, 1fr); gap: 2.5rem; padding-top: 2rem; }
+.form-heading, .library-heading, .actions { display: flex; align-items: center; justify-content: space-between; gap: 1rem; }
+.eyebrow { margin: 0 0 .2rem; color: var(--accent-dark); font-size: .75rem; font-weight: 700; text-transform: uppercase; }
+h1, h2 { margin: 0; letter-spacing: 0; }
+h1 { font-size: 1.8rem; } h2 { font-size: 1.1rem; }
+.grant { display: flex; align-items: center; gap: .45rem; white-space: nowrap; }
+.grant input { width: auto; min-height: auto; accent-color: var(--accent); }
+.identity-grid, .stats-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .85rem; margin: 1.5rem 0; }
+fieldset { border: 1px solid var(--line); margin: 0; padding: 1rem; } legend { padding: 0 .35rem; color: var(--muted); }
+.stats-grid { grid-template-columns: repeat(6, minmax(0, 1fr)); margin: 0; }
+.gameplay-fields { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; }
+.gameplay-group { border-left: 3px solid var(--coral); padding-left: .65rem; }.gameplay-group h3 { font-size: .9rem; margin: 0 0 .55rem; }.gameplay-group .stats-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .55rem; }
+.actions { justify-content: flex-end; margin-top: 1.25rem; }
+button { min-height: 38px; padding: .45rem .8rem; border: 1px solid var(--accent-dark); border-radius: 3px; background: transparent; color: var(--accent-dark); cursor: pointer; }
+button[type="submit"] { background: var(--accent); color: white; }
+button:hover { background: #dfece5; } button[type="submit"]:hover { background: var(--accent-dark); }
+#status { min-height: 1.3rem; margin: 1rem 0 0; color: var(--accent-dark); }
+#status.error { color: #a33020; }
+.library { border-left: 1px solid var(--line); padding-left: 1.5rem; }
+.library-heading > div { display: flex; gap: .75rem; font-size: .85rem; }
+a, .import { color: var(--accent-dark); text-decoration: underline; cursor: pointer; }
+.import input { display: none; }
+#saved-cards { padding: 0; margin: 1rem 0; list-style: none; }
+#saved-cards li { border-bottom: 1px solid var(--line); padding: .75rem 0; display: grid; grid-template-columns: 1fr auto; gap: .5rem; }
+.saved-name { display: block; font-weight: 700; }.saved-meta { color: var(--muted); font-size: .8rem; }.saved-actions { display: flex; gap: .3rem; }.saved-actions button { min-height: 28px; padding: .2rem .4rem; font-size: .75rem; }
+@media (max-width: 760px) { .topbar { padding: 0 1rem; } nav { gap: .75rem; font-size: .85rem; } main { padding: 1.25rem 1rem 2rem; }.workspace { grid-template-columns: 1fr; gap: 2rem; }.library { border-left: 0; border-top: 1px solid var(--line); padding: 1.5rem 0 0; }.identity-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }.stats-grid, .gameplay-fields { grid-template-columns: repeat(2, minmax(0, 1fr)); }.form-heading { align-items: flex-start; flex-direction: column; }.search-row { grid-template-columns: 1fr; } }

--- a/server/editor/app.js
+++ b/server/editor/app.js
@@ -1,0 +1,176 @@
+const api = "/local-editor/api";
+const form = document.querySelector("#card-form");
+const status = document.querySelector("#status");
+const search = document.querySelector("#player-search");
+const results = document.querySelector("#player-results");
+const attributes = [...document.querySelectorAll("[data-attribute]")];
+const gameplayGroups = {
+  Pace: ["acceleration", "sprintspeed"],
+  Shooting: ["positioning", "finishing", "shotpower", "longshots", "volleys", "penalties"],
+  Passing: ["vision", "crossing", "freekickaccuracy", "shortpassing", "longpassing", "curve"],
+  Dribbling: ["agility", "balance", "reactions", "ballcontrol", "dribbling"],
+  Defending: ["interceptions", "headingaccuracy", "marking", "standingtackle", "slidingtackle"],
+  Physical: ["jumping", "stamina", "strength", "aggression"],
+  Goalkeeping: ["gkdiving", "gkhandling", "gkkicking", "gkreflexes", "gkpositioning"],
+};
+const gameplayFields = Object.values(gameplayGroups).flat();
+let selectedBase = null;
+let searchTimer = null;
+
+function labelFor(field) {
+  return field.replace(/^gk/, "GK ").replace(/([a-z])([A-Z])/g, "$1 $2").replace(/^./, (letter) => letter.toUpperCase());
+}
+
+function createGameplayInputs() {
+  const container = document.querySelector("#gameplay-fields");
+  for (const [group, fields] of Object.entries(gameplayGroups)) {
+    const section = document.createElement("section");
+    section.className = "gameplay-group";
+    const heading = document.createElement("h3");
+    heading.textContent = group;
+    const grid = document.createElement("div");
+    grid.className = "stats-grid";
+    for (const field of fields) {
+      const label = document.createElement("label");
+      label.textContent = labelFor(field);
+      const input = document.createElement("input");
+      input.id = `stat-${field}`;
+      input.type = "number";
+      input.min = "1";
+      input.max = "99";
+      input.required = true;
+      label.append(input);
+      grid.append(label);
+    }
+    section.append(heading, grid);
+    container.append(section);
+  }
+}
+
+function setStatus(message, error = false) {
+  status.textContent = message;
+  status.classList.toggle("error", error);
+}
+
+function setCard(card) {
+  document.querySelector("#card-id").value = card.cardId || "";
+  document.querySelector("#asset-id").value = card.assetId;
+  document.querySelector("#player-name").textContent = card.name || "Selected player";
+  document.querySelector("#rating").value = card.rating;
+  document.querySelector("#rare-flag").value = String(card.rareFlag);
+  document.querySelector("#team-id").value = card.teamId;
+  document.querySelector("#league-id").value = card.leagueId;
+  attributes.forEach((input, index) => { input.value = card.attributes[index]; });
+  for (const field of gameplayFields) document.querySelector(`#stat-${field}`).value = card.gameplayAttributes[field];
+  for (const field of ["weakfootabilitytypecode", "skillmoves", "preferredfoot", "attackingworkrate", "defensiveworkrate"]) {
+    document.querySelector(`#${field}`).value = String(card.traits[field]);
+  }
+}
+
+function formData() {
+  return {
+    assetId: Number(document.querySelector("#asset-id").value),
+    rating: Number(document.querySelector("#rating").value),
+    rareFlag: Number(document.querySelector("#rare-flag").value),
+    teamId: Number(document.querySelector("#team-id").value),
+    leagueId: Number(document.querySelector("#league-id").value),
+    attributes: attributes.map((input) => Number(input.value)),
+    gameplayAttributes: Object.fromEntries(gameplayFields.map((field) => [field, Number(document.querySelector(`#stat-${field}`).value)])),
+    traits: Object.fromEntries(["weakfootabilitytypecode", "skillmoves", "preferredfoot", "attackingworkrate", "defensiveworkrate"].map((field) => [field, Number(document.querySelector(`#${field}`).value)])),
+  };
+}
+
+async function request(path, options = {}) {
+  const response = await fetch(`${api}${path}`, options);
+  const document = await response.json();
+  if (!response.ok) throw new Error(document.error || "Request failed");
+  return document;
+}
+
+async function searchPlayers() {
+  const query = search.value.trim();
+  if (query.length < 2) { results.replaceChildren(); return; }
+  const responseDocument = await request(`/players?q=${encodeURIComponent(query)}`);
+  results.replaceChildren(...responseDocument.players.map((player) => {
+    const option = document.createElement("option");
+    option.value = String(player.assetId);
+    option.textContent = `${player.name} | ${player.rating} ${player.position}`;
+    option.dataset.player = JSON.stringify(player);
+    return option;
+  }));
+}
+
+function resetToBase() {
+  if (!selectedBase) return;
+  setCard(selectedBase);
+  document.querySelector("#card-id").value = "";
+}
+
+async function loadCards() {
+  const responseDocument = await request("/cards");
+  const list = document.querySelector("#saved-cards");
+  list.replaceChildren(...responseDocument.cards.map((card) => {
+    const item = document.createElement("li");
+    const text = document.createElement("div");
+    const name = document.createElement("span");
+    const meta = document.createElement("span");
+    name.className = "saved-name";
+    meta.className = "saved-meta";
+    name.textContent = `${card.name} ${card.rating}`;
+    meta.textContent = `v${card.version} | ${card.position} | ${card.cardType}`;
+    text.append(name, meta);
+    const actions = document.createElement("div");
+    actions.className = "saved-actions";
+    for (const [label, action] of [["Edit", "edit"], ["Grant", "grant"], ["Delete", "delete"]]) {
+      const button = document.createElement("button");
+      button.type = "button";
+      button.textContent = label;
+      button.addEventListener("click", async () => {
+        if (action === "edit") { setCard(card); selectedBase = card; return; }
+        if (action === "delete") { await request(`/cards/${card.cardId}`, { method: "DELETE" }); await loadCards(); return; }
+        await request(`/cards/${card.cardId}/grant`, { method: "POST" }); setStatus("Card granted to My Club.");
+      });
+      actions.append(button);
+    }
+    item.append(text, actions);
+    return item;
+  }));
+}
+
+search.addEventListener("input", () => {
+  clearTimeout(searchTimer);
+  searchTimer = setTimeout(() => searchPlayers().catch((error) => setStatus(error.message, true)), 180);
+});
+results.addEventListener("change", () => {
+  const option = results.selectedOptions[0];
+  if (!option) return;
+  selectedBase = JSON.parse(option.dataset.player);
+  setCard(selectedBase);
+});
+document.querySelector("#reset").addEventListener("click", resetToBase);
+form.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  try {
+    const cardId = document.querySelector("#card-id").value;
+    const saved = await request(cardId ? `/cards/${cardId}` : "/cards", {
+      method: cardId ? "PUT" : "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ card: formData(), grant: document.querySelector("#grant").checked }),
+    });
+    setCard(saved.card);
+    setStatus(saved.granted ? "Card saved and granted." : "Card saved.");
+    await loadCards();
+  } catch (error) { setStatus(error.message, true); }
+});
+document.querySelector("#import").addEventListener("change", async (event) => {
+  const file = event.target.files[0];
+  if (!file) return;
+  try {
+    await request("/cards/import", { method: "POST", headers: { "content-type": "application/json" }, body: await file.text() });
+    setStatus("Cards imported.");
+    await loadCards();
+  } catch (error) { setStatus(error.message, true); }
+  event.target.value = "";
+});
+createGameplayInputs();
+loadCards().catch((error) => setStatus(error.message, true));

--- a/server/editor/index.html
+++ b/server/editor/index.html
@@ -1,0 +1,101 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>FUT Workshop</title>
+  <link rel="stylesheet" href="/local-editor/app.css">
+</head>
+<body>
+  <header class="topbar">
+    <div class="brand">FUT Workshop</div>
+    <nav aria-label="Workshop sections">
+      <a class="active" href="/local-editor/">Cards</a>
+      <span>Packs</span>
+      <span>Tournaments</span>
+    </nav>
+  </header>
+  <main>
+    <section class="picker" aria-label="Base player">
+      <label for="player-search">Base player</label>
+      <div class="search-row">
+        <input id="player-search" type="search" autocomplete="off" placeholder="Search a player">
+        <select id="player-results" size="1" aria-label="Matching players"></select>
+      </div>
+    </section>
+
+    <section class="workspace">
+      <form id="card-form" class="editor" autocomplete="off">
+        <input id="card-id" type="hidden">
+        <div class="form-heading">
+          <div>
+            <p class="eyebrow">Card editor</p>
+            <h1 id="player-name">Choose a base player</h1>
+          </div>
+          <label class="grant"><input id="grant" type="checkbox" checked> Grant to My Club</label>
+        </div>
+        <input id="asset-id" type="hidden">
+        <div class="identity-grid">
+          <label>Overall<input id="rating" type="number" min="1" max="99" required></label>
+          <label>Rarity
+            <select id="rare-flag">
+              <option value="0">Common</option>
+              <option value="1">Rare</option>
+              <option value="3">In Form</option>
+              <option value="5">Team of the Year</option>
+              <option value="7">Green</option>
+              <option value="8">Man of the Match</option>
+              <option value="11">Blue</option>
+              <option value="12">Legend</option>
+            </select>
+          </label>
+          <label>Team ID<input id="team-id" type="number" min="1" required></label>
+          <label>League ID<input id="league-id" type="number" min="1" required></label>
+        </div>
+        <fieldset>
+          <legend>Face attributes</legend>
+          <div class="stats-grid">
+            <label>PAC<input data-attribute="0" type="number" min="0" max="99" required></label>
+            <label>SHO<input data-attribute="1" type="number" min="0" max="99" required></label>
+            <label>PAS<input data-attribute="2" type="number" min="0" max="99" required></label>
+            <label>DRI<input data-attribute="3" type="number" min="0" max="99" required></label>
+            <label>DEF<input data-attribute="4" type="number" min="0" max="99" required></label>
+            <label>PHY<input data-attribute="5" type="number" min="0" max="99" required></label>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Gameplay attributes</legend>
+          <div id="gameplay-fields" class="gameplay-fields"></div>
+        </fieldset>
+        <fieldset>
+          <legend>Traits</legend>
+          <div class="identity-grid">
+            <label>Weak foot<select id="weakfootabilitytypecode"><option value="1">1 star</option><option value="2">2 stars</option><option value="3">3 stars</option><option value="4">4 stars</option><option value="5">5 stars</option></select></label>
+            <label>Skill moves<select id="skillmoves"><option value="0">0 stars</option><option value="1">1 star</option><option value="2">2 stars</option><option value="3">3 stars</option><option value="4">4 stars</option></select></label>
+            <label>Preferred foot<select id="preferredfoot"><option value="1">Left</option><option value="2">Right</option></select></label>
+            <label>Attacking work rate<select id="attackingworkrate"><option value="0">Low</option><option value="1">Medium</option><option value="2">High</option></select></label>
+            <label>Defensive work rate<select id="defensiveworkrate"><option value="0">Low</option><option value="1">Medium</option><option value="2">High</option></select></label>
+          </div>
+        </fieldset>
+        <div class="actions">
+          <button id="reset" type="button">Reset values</button>
+          <button id="save" type="submit">Save card</button>
+        </div>
+        <p id="status" role="status"></p>
+      </form>
+
+      <aside class="library">
+        <div class="library-heading">
+          <h2>Saved cards</h2>
+          <div>
+            <a id="export" href="/local-editor/api/cards/export">Export</a>
+            <label class="import">Import<input id="import" type="file" accept="application/json"></label>
+          </div>
+        </div>
+        <ol id="saved-cards"></ol>
+      </aside>
+    </section>
+  </main>
+  <script src="/local-editor/app.js"></script>
+</body>
+</html>

--- a/server/local_identity.py
+++ b/server/local_identity.py
@@ -12,7 +12,9 @@ from contextlib import closing
 from pathlib import Path
 from typing import Any
 
+from custom_cards import CustomCardCatalog
 from fifa14_ids import definition_id_for, resource_id_for
+from player_data import GAMEPLAY_FIELDS, TRAIT_RANGES, load_player_data
 
 
 DEFAULT_NUCLEUS_ID = 1_000_001
@@ -30,6 +32,7 @@ MANAGER_CATALOG_PATH = Path(__file__).with_name("manager-catalog.v237.json")
 SPECIAL_CATALOG_PATH = Path(__file__).with_name("fifa14-special-catalog.v240.json")
 LEGEND_CATALOG_PATH = Path(__file__).with_name("fifa14-legend-catalog.v24013.json")
 CONSUMABLE_CATALOG_PATH = Path(__file__).with_name("fifa14-consumable-catalog.v2412.json")
+PLAYER_DATA_CACHE_PATH = Path(__file__).resolve().parent.parent / "artifacts" / "fifa14-player-data-v1.json"
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -49,6 +52,16 @@ CONSUMABLE_CATALOG_DOCUMENT = _load_json(CONSUMABLE_CATALOG_PATH)
 PACK_DEFINITIONS = {int(entry["packType"]): entry for entry in PACK_CATALOG_DOCUMENT.get("packs", [])}
 PLAYER_CATALOG = list(PLAYER_CATALOG_DOCUMENT.get("players", []))
 PLAYER_BY_ASSET = {int(player["assetId"]): player for player in PLAYER_CATALOG}
+FULL_PLAYER_DATA_BY_ASSET, PLAYER_DATA_ERROR = load_player_data(PLAYER_DATA_CACHE_PATH)
+EDITOR_PLAYER_BY_ASSET: dict[int, dict[str, Any]] = {}
+for asset_id, player in PLAYER_BY_ASSET.items():
+    detailed = FULL_PLAYER_DATA_BY_ASSET.get(asset_id)
+    if detailed is None:
+        continue
+    merged = dict(player)
+    merged["gameplayAttributes"] = dict(detailed["gameplayAttributes"])
+    merged["traits"] = dict(detailed["traits"])
+    EDITOR_PLAYER_BY_ASSET[asset_id] = merged
 SPECIAL_PLAYER_CATALOG = list(SPECIAL_CATALOG_DOCUMENT.get("players", []))
 # World Cup cards belonged to the separate FIFA 14 World Cup mode and the three
 # old fuzzy "legend" matches are superseded by the verified 42-card legend file.
@@ -127,6 +140,7 @@ FULL_CLUB_ITEM_BASE = 171_000_000_000
 FULL_SPECIAL_ITEM_BASE = 172_000_000_000
 FULL_LEGEND_ITEM_BASE = 173_000_000_000
 PACK_ITEM_BASE = 180_000_000_000
+CUSTOM_CARD_ITEM_BASE = 196_000_000_000
 PACK_FIDELITY_SCHEMA = "fifa14-v24012-pack-fidelity"
 LEGACY_INTRO_ITEM_BASE = 170_000_000_000
 
@@ -145,6 +159,9 @@ class LocalIdentityStore:
         self.database = Path(database)
         self.database.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.RLock()
+        self.custom_cards = CustomCardCatalog(
+            self.database.with_name("custom-cards.v1.json"), EDITOR_PLAYER_BY_ASSET
+        )
         self._initialize(initial_mode)
 
     def _connect(self) -> sqlite3.Connection:
@@ -279,6 +296,13 @@ class LocalIdentityStore:
                 CREATE TABLE IF NOT EXISTS schema_meta (
                     meta_key TEXT PRIMARY KEY,
                     meta_value TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS custom_card_grants (
+                    persona_id INTEGER NOT NULL,
+                    card_id TEXT NOT NULL,
+                    item_id INTEGER NOT NULL UNIQUE,
+                    created_at INTEGER NOT NULL,
+                    PRIMARY KEY (persona_id, card_id)
                 );
                 CREATE TABLE IF NOT EXISTS manager_reference (
                     manager_key INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -472,6 +496,76 @@ class LocalIdentityStore:
 
     def profile_kind(self) -> str:
         return "returning-local-club-pc" if self.has_club() else "first-use-no-club-pc"
+
+    def custom_card_definitions(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return self.custom_cards.list_cards()
+
+    def save_custom_card(self, document: dict[str, Any], *, card_id: str | None = None, grant: bool = False) -> dict[str, Any]:
+        with self._lock:
+            card = self.custom_cards.save(document, card_id=card_id)
+            result = {"card": card, "granted": None}
+            if grant:
+                result["granted"] = self.grant_custom_card(str(card["cardId"]))
+            return result
+
+    def delete_custom_card(self, card_id: str) -> bool:
+        with self._lock:
+            return self.custom_cards.delete(card_id)
+
+    def export_custom_cards(self) -> dict[str, Any]:
+        with self._lock:
+            return self.custom_cards.export_document()
+
+    def import_custom_cards(self, document: dict[str, Any], *, replace: bool = False) -> list[dict[str, Any]]:
+        with self._lock:
+            return self.custom_cards.import_document(document, replace=replace)
+
+    def grant_custom_card(self, card_id: str) -> dict[str, Any]:
+        with self._lock, closing(self._connect()) as connection, connection:
+            card = self.custom_cards.get(card_id)
+            if card is None:
+                raise ValueError("custom card does not exist")
+            identity = self._identity(connection)
+            persona_id = int(identity["persona_id"])
+            if connection.execute("SELECT 1 FROM clubs WHERE persona_id=?", (persona_id,)).fetchone() is None:
+                raise ValueError("a FUT club is required before granting a custom card")
+            grant = connection.execute(
+                "SELECT item_id FROM custom_card_grants WHERE persona_id=? AND card_id=?",
+                (persona_id, card_id),
+            ).fetchone()
+            item_id = int(grant["item_id"]) if grant is not None else int(connection.execute(
+                "SELECT COALESCE(MAX(item_id), ?) + 1 FROM items WHERE persona_id=? AND item_id>=?",
+                (CUSTOM_CARD_ITEM_BASE - 1, persona_id, CUSTOM_CARD_ITEM_BASE),
+            ).fetchone()[0])
+            source = dict(card)
+            source.update({
+                "untradeable": True,
+                "tradeable": False,
+                "contract": 99,
+                "fitness": 99,
+                "morale": 99,
+                "pile": 7,
+            })
+            payload = self._canonical_player_payload(
+                item_id=item_id,
+                asset_id=int(card["assetId"]),
+                existing=source,
+                pile=7,
+            )
+            encoded = json.dumps(payload, separators=(",", ":"), ensure_ascii=False)
+            connection.execute(
+                "INSERT INTO items(item_id,persona_id,asset_id,item_type,pile,tradeable,payload) VALUES(?,?,?,?, 'club',0,?) "
+                "ON CONFLICT(item_id) DO UPDATE SET asset_id=excluded.asset_id,item_type=excluded.item_type,"
+                "pile='club',tradeable=0,payload=excluded.payload",
+                (item_id, persona_id, int(card["assetId"]), PLAYER_ITEM_TYPE, encoded),
+            )
+            connection.execute(
+                "INSERT INTO custom_card_grants(persona_id,card_id,item_id,created_at) VALUES(?,?,?,?) "
+                "ON CONFLICT(persona_id,card_id) DO UPDATE SET item_id=excluded.item_id",
+                (persona_id, card_id, item_id, int(time.time())),
+            )
+            return {"card": card, "itemData": payload, "updated": grant is not None}
 
     def account_info(self) -> dict[str, Any]:
         with self._lock, closing(self._connect()) as connection:
@@ -1705,6 +1799,20 @@ class LocalIdentityStore:
             ):
                 if key in source:
                     player[key] = source[key]
+            gameplay_source = source.get("gameplayAttributes")
+            traits_source = source.get("traits")
+            if isinstance(gameplay_source, dict):
+                player["gameplayAttributes"] = {
+                    str(field): int(value)
+                    for field, value in gameplay_source.items()
+                    if field is not None and value is not None
+                }
+            if isinstance(traits_source, dict):
+                player["traits"] = {
+                    str(field): int(value)
+                    for field, value in traits_source.items()
+                    if field is not None and value is not None
+                }
             # Persisted ItemData stores the six face attributes as attributeArray/
             # attributeList rather than the catalogue-only `attributes` key.
             # Preserve those special/Legend values during later repair passes.
@@ -1757,6 +1865,18 @@ class LocalIdentityStore:
         discard_value = self._bounded_int(source.get("discardValue", 0), 0)
         if discard_value <= 0 and source_tradeable and not source_untradeable:
             discard_value = self._player_discard_value(player)
+        gameplay_source = source.get("gameplayAttributes")
+        gameplay_overrides = {
+            field: int(gameplay_source[field])
+            for field in GAMEPLAY_FIELDS
+            if isinstance(gameplay_source, dict) and field in gameplay_source
+        }
+        traits_source = source.get("traits")
+        trait_overrides = {
+            field: int(traits_source[field])
+            for field in TRAIT_RANGES
+            if isinstance(traits_source, dict) and field in traits_source
+        }
 
         # BETA 2.25.0: keep the native-critical ItemData members first.  FIFA
         # 14's player parser is sensitive to this stream, and the older local
@@ -1782,6 +1902,8 @@ class LocalIdentityStore:
             "suspension": self._bounded_int(source.get("suspension", 0), 0),
             "training": self._bounded_int(source.get("training", 0), 0),
             "playStyle": self._bounded_int(source.get("playStyle", player.get("playStyle", 0)), 0),
+            **gameplay_overrides,
+            **trait_overrides,
             "discardValue": discard_value,
             "lastSalePrice": self._bounded_int(source.get("lastSalePrice", 0), 0),
             "timestamp": self._bounded_int(source.get("timestamp", int(time.time())), int(time.time()), minimum=1),
@@ -1829,9 +1951,27 @@ class LocalIdentityStore:
             payload["specialCard"] = True
             payload["cardType"] = str(player.get("cardType", source.get("cardType", "special")))
             payload["version"] = version
+
+        gameplay_source = source.get("gameplayAttributes")
+        if isinstance(gameplay_source, dict):
+            gameplay_attributes = {
+                str(field): int(value)
+                for field, value in gameplay_source.items()
+                if field is not None and value is not None
+            }
+            payload["gameplayAttributes"] = gameplay_attributes
+            payload.update(gameplay_attributes)
+        traits_source = source.get("traits")
+        if isinstance(traits_source, dict):
+            traits = {
+                str(field): int(value)
+                for field, value in traits_source.items()
+                if field is not None and value is not None
+            }
+            payload["traits"] = traits
+            payload.update(traits)
         return payload
 
-    def _v27_player_payload(self, *, item_id: int, pack: dict[str, Any], index: int) -> dict[str, Any]:
         asset_id = int(pack["squad"][index])
         initial = {
             "formation": str(pack.get("formation") or "f442"),
@@ -1850,7 +1990,6 @@ class LocalIdentityStore:
             pack=pack,
             index=index,
         )
-
     def _repair_owned_items_locked(self, connection: sqlite3.Connection, persona_id: int | None = None) -> int:
         repaired = 0
         params: tuple[Any, ...] = ()

--- a/server/player_data.py
+++ b/server/player_data.py
@@ -1,0 +1,55 @@
+"""Validated access to the read-only full player-data cache emitted at launch."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA = "fifa14-player-data-v1"
+GAMEPLAY_FIELDS = (
+    "acceleration", "sprintspeed", "positioning", "finishing", "shotpower", "longshots", "volleys", "penalties",
+    "vision", "crossing", "freekickaccuracy", "shortpassing", "longpassing", "curve",
+    "agility", "balance", "reactions", "ballcontrol", "dribbling",
+    "interceptions", "headingaccuracy", "marking", "standingtackle", "slidingtackle",
+    "jumping", "stamina", "strength", "aggression",
+    "gkdiving", "gkhandling", "gkkicking", "gkreflexes", "gkpositioning",
+)
+TRAIT_RANGES = {
+    "weakfootabilitytypecode": (1, 5), "skillmoves": (0, 4), "preferredfoot": (1, 2),
+    "attackingworkrate": (0, 2), "defensiveworkrate": (0, 2),
+}
+
+
+def load_player_data(path: Path) -> tuple[dict[int, dict[str, Any]], str | None]:
+    if not path.is_file():
+        return {}, "player-data cache is missing; launch FIFA Local FUT to generate it"
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        return {}, f"could not read player-data cache: {error}"
+    if not isinstance(document, dict) or document.get("schema") != SCHEMA:
+        return {}, "player-data cache has an unsupported schema"
+    rows = document.get("players")
+    if not isinstance(rows, list):
+        return {}, "player-data cache has no player list"
+    result: dict[int, dict[str, Any]] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        try:
+            asset_id = int(row["assetId"])
+            stats = row["gameplayAttributes"]
+            traits = row["traits"]
+            if asset_id <= 0 or not isinstance(stats, dict) or not isinstance(traits, dict):
+                continue
+            if any(not 1 <= int(stats[field]) <= 99 for field in GAMEPLAY_FIELDS):
+                continue
+            if any(not minimum <= int(traits[field]) <= maximum for field, (minimum, maximum) in TRAIT_RANGES.items()):
+                continue
+        except (KeyError, TypeError, ValueError):
+            continue
+        result[asset_id] = dict(row)
+    if not result:
+        return {}, "player-data cache contains no valid player rows"
+    return result, None

--- a/server/probe.py
+++ b/server/probe.py
@@ -28,10 +28,19 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.x509.oid import NameOID
 
 SERVER_DIRECTORY = Path(__file__).resolve().parent
+EDITOR_DIRECTORY = SERVER_DIRECTORY / "editor"
 if str(SERVER_DIRECTORY) not in sys.path:
     sys.path.insert(0, str(SERVER_DIRECTORY))
 
 from local_identity import LocalIdentityStore, PLAYER_CATALOG, PLAYER_BY_ASSET, PLAYER_REFERENCE_BY_ASSET
+from local_identity import (
+    EDITOR_PLAYER_BY_ASSET,
+    PLAYER_DATA_ERROR,
+    LocalIdentityStore,
+    PLAYER_CATALOG,
+    PLAYER_BY_ASSET,
+    PLAYER_REFERENCE_BY_ASSET,
+)
 from beta_identity import BetaIdentityStore
 
 
@@ -2137,6 +2146,34 @@ class HttpProbe(BaseHTTPRequestHandler):
         return "/2014/fut/items/web/" in lowered and lowered.endswith(".json")
 
     @staticmethod
+    def _local_editor_asset(path_without_query: str) -> tuple[Path, str] | None:
+        mapping = {
+            "/local-editor": (EDITOR_DIRECTORY / "index.html", "text/html; charset=utf-8"),
+            "/local-editor/": (EDITOR_DIRECTORY / "index.html", "text/html; charset=utf-8"),
+            "/local-editor/index.html": (EDITOR_DIRECTORY / "index.html", "text/html; charset=utf-8"),
+            "/local-editor/app.css": (EDITOR_DIRECTORY / "app.css", "text/css; charset=utf-8"),
+            "/local-editor/app.js": (EDITOR_DIRECTORY / "app.js", "application/javascript; charset=utf-8"),
+        }
+        return mapping.get(path_without_query)
+
+    @staticmethod
+    def _editor_player_summary(player: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "assetId": int(player["assetId"]),
+            "name": str(player.get("name", "")),
+            "commonName": str(player.get("commonName", player.get("name", ""))),
+            "rating": int(player.get("rating", 0)),
+            "position": str(player.get("position", "CM")),
+            "teamId": int(player.get("teamId", 0)),
+            "leagueId": int(player.get("leagueId", 0)),
+            "nation": int(player.get("nation", 0)),
+            "rareFlag": int(player.get("rareFlag", 0)),
+            "attributes": [int(value) for value in player.get("attributes", [])[:6]],
+            "gameplayAttributes": dict(player.get("gameplayAttributes", {})),
+            "traits": dict(player.get("traits", {})),
+        }
+
+    @staticmethod
     def _is_fut_static_image_path(path_without_query: str) -> bool:
         lowered = path_without_query.lower()
         return "/fut/items/images/" in lowered and lowered.endswith((".png", ".jpg", ".jpeg"))
@@ -2517,6 +2554,95 @@ class HttpProbe(BaseHTTPRequestHandler):
                 response_name="v237-returning-league-nation-locstrings-xml",
                 status=200, bytes=len(payload),
             )
+        elif probe_name == "fut-http" and path_without_query.startswith("/local-editor"):
+            editor_asset = self._local_editor_asset(path_without_query)
+            try:
+                if editor_asset is not None:
+                    asset_path, content_type = editor_asset
+                    payload = asset_path.read_bytes()
+                    status = 200
+                    response_name = "local-editor-asset"
+                elif identity_store is None:
+                    raise ValueError("local identity store is unavailable")
+                elif PLAYER_DATA_ERROR:
+                    raise ValueError(PLAYER_DATA_ERROR)
+                elif path_without_query == "/local-editor/api/players" and effective_method == "GET":
+                    query = parse_qs(urlsplit(self.path).query, keep_blank_values=True)
+                    needle = str(query.get("q", [""])[0]).strip().casefold()
+                    players = [] if len(needle) < 2 else [
+                        self._editor_player_summary(player)
+                        for player in EDITOR_PLAYER_BY_ASSET.values()
+                        if needle in str(player.get("name", "")).casefold()
+                        or needle in str(player.get("assetId", ""))
+                    ][:30]
+                    payload = build_fut_json_payload({"players": players})
+                    content_type = "application/json; charset=utf-8"
+                    status = 200
+                    response_name = "local-editor-player-search"
+                elif path_without_query == "/local-editor/api/cards" and effective_method == "GET":
+                    payload = build_fut_json_payload({"cards": identity_store.custom_card_definitions()})
+                    content_type = "application/json; charset=utf-8"
+                    status = 200
+                    response_name = "local-editor-card-list"
+                elif path_without_query == "/local-editor/api/cards/export" and effective_method == "GET":
+                    payload = build_fut_json_payload(identity_store.export_custom_cards())
+                    content_type = "application/json; charset=utf-8"
+                    status = 200
+                    response_name = "local-editor-card-export"
+                elif path_without_query == "/local-editor/api/cards/import" and effective_method == "POST":
+                    document = json.loads(body.decode("utf-8"))
+                    if not isinstance(document, dict):
+                        raise ValueError("custom card import must be a JSON object")
+                    payload = build_fut_json_payload({"cards": identity_store.import_custom_cards(document)})
+                    content_type = "application/json; charset=utf-8"
+                    status = 200
+                    response_name = "local-editor-card-import"
+                elif path_without_query == "/local-editor/api/cards" and effective_method == "POST":
+                    document = json.loads(body.decode("utf-8"))
+                    if not isinstance(document, dict) or not isinstance(document.get("card"), dict):
+                        raise ValueError("custom card save requires a card object")
+                    payload = build_fut_json_payload(identity_store.save_custom_card(
+                        document["card"], grant=bool(document.get("grant", False))
+                    ))
+                    content_type = "application/json; charset=utf-8"
+                    status = 200
+                    response_name = "local-editor-card-created"
+                else:
+                    card_match = re.fullmatch(r"/local-editor/api/cards/([^/]+)(/grant)?", path_without_query)
+                    if card_match is None:
+                        raise ValueError("unknown local editor route")
+                    card_id, grant_suffix = card_match.groups()
+                    if grant_suffix and effective_method == "POST":
+                        document = identity_store.grant_custom_card(card_id)
+                        response_name = "local-editor-card-granted"
+                    elif not grant_suffix and effective_method == "PUT":
+                        request = json.loads(body.decode("utf-8"))
+                        if not isinstance(request, dict) or not isinstance(request.get("card"), dict):
+                            raise ValueError("custom card save requires a card object")
+                        document = identity_store.save_custom_card(
+                            request["card"], card_id=card_id, grant=bool(request.get("grant", False))
+                        )
+                        response_name = "local-editor-card-updated"
+                    elif not grant_suffix and effective_method == "DELETE":
+                        if not identity_store.delete_custom_card(card_id):
+                            raise ValueError("custom card does not exist")
+                        document = {"deleted": True, "cardId": card_id}
+                        response_name = "local-editor-card-deleted"
+                    else:
+                        raise ValueError("unsupported local editor method")
+                    payload = build_fut_json_payload(document)
+                    content_type = "application/json; charset=utf-8"
+                    status = 200
+            except (UnicodeDecodeError, json.JSONDecodeError, ValueError, OSError) as error:
+                payload = build_fut_json_payload({"error": str(error)})
+                content_type = "application/json; charset=utf-8"
+                status = 400
+                response_name = "local-editor-error"
+            self.send_response(status)
+            self.send_header("content-type", content_type)
+            self.send_header("cache-control", "no-store")
+            self.send_header("connection", "close")
+            emit(response_name, listener=probe_name, method=self.command, path=self.path, status=status, bytes=len(payload))
         elif (
             probe_name in {"fut-http", "dynamic-http"}
             and self._is_fut_static_metadata_path(path_without_query)

--- a/tests/test_custom_cards.py
+++ b/tests/test_custom_cards.py
@@ -1,0 +1,127 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from custom_cards import CustomCardCatalog
+from fifa14_ids import definition_id_for, resource_id_for
+from local_identity import LocalIdentityStore
+
+
+class CustomCardCatalogTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.base = {
+            1001: {
+                "assetId": 1001,
+                "name": "Test Player",
+                "commonName": "Test",
+                "position": "CM",
+                "nation": 1,
+                "nationName": "England",
+                "rating": 80,
+                "teamId": 10,
+                "leagueId": 2,
+                "rareFlag": 1,
+                "playStyle": 1,
+                "attributes": [80] * 6,
+                "gameplayAttributes": {
+                    "acceleration": 80,
+                    "sprintspeed": 80,
+                    "positioning": 80,
+                    "finishing": 80,
+                    "shotpower": 80,
+                    "longshots": 80,
+                    "volleys": 80,
+                    "penalties": 80,
+                    "vision": 80,
+                    "crossing": 80,
+                    "freekickaccuracy": 80,
+                    "shortpassing": 80,
+                    "longpassing": 80,
+                    "curve": 80,
+                    "agility": 80,
+                    "balance": 80,
+                    "reactions": 80,
+                    "ballcontrol": 80,
+                    "dribbling": 80,
+                    "interceptions": 80,
+                    "headingaccuracy": 80,
+                    "marking": 80,
+                    "standingtackle": 80,
+                    "slidingtackle": 80,
+                    "jumping": 80,
+                    "stamina": 80,
+                    "strength": 80,
+                    "aggression": 80,
+                    "gkdiving": 80,
+                    "gkhandling": 80,
+                    "gkkicking": 80,
+                    "gkreflexes": 80,
+                    "gkpositioning": 80,
+                },
+                "traits": {
+                    "weakfootabilitytypecode": 3,
+                    "skillmoves": 3,
+                    "preferredfoot": 1,
+                    "attackingworkrate": 1,
+                    "defensiveworkrate": 1,
+                },
+            }
+        }
+
+    def test_special_card_uses_versioned_resource_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "custom-cards.json"
+            catalog = CustomCardCatalog(path, self.base)
+            card = catalog.save(
+                {
+                    "assetId": 1001,
+                    "rating": 85,
+                    "teamId": 10,
+                    "leagueId": 2,
+                    "rareFlag": 2,
+                    "attributes": [85] * 6,
+                    "gameplayAttributes": self.base[1001]["gameplayAttributes"],
+                    "traits": self.base[1001]["traits"],
+                    "version": 50,
+                }
+            )
+
+            self.assertEqual(card["definitionId"], 1001)
+            self.assertEqual(card["resourceId"], resource_id_for(1001, 50))
+            self.assertNotEqual(card["resourceId"], definition_id_for(1001, 50))
+
+    def test_custom_payload_keeps_gameplay_stats_and_traits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            database = Path(tmpdir) / "local-fut.db"
+            store = LocalIdentityStore(database, initial_mode="new")
+            asset_id = 158023
+            source = {
+                "assetId": asset_id,
+                "rating": 85,
+                "teamId": 10,
+                "leagueId": 2,
+                "rareFlag": 2,
+                "attributes": [85] * 6,
+                "gameplayAttributes": self.base.get(asset_id, self.base[1001])["gameplayAttributes"],
+                "traits": self.base.get(asset_id, self.base[1001])["traits"],
+                "untradeable": True,
+                "pile": 7,
+            }
+
+            payload = store._canonical_player_payload(item_id=9001, asset_id=asset_id, existing=source, pile=7)
+
+            self.assertEqual(payload["gameplayAttributes"]["acceleration"], 80)
+            self.assertEqual(payload["traits"]["preferredfoot"], 1)
+            self.assertIn("positioning", payload["gameplayAttributes"])
+            self.assertIn("weakfootabilitytypecode", payload["traits"])
+            self.assertEqual(payload["acceleration"], 80)
+            self.assertEqual(payload["positioning"], 80)
+            self.assertEqual(payload["preferredfoot"], 1)
+            self.assertEqual(payload["skillmoves"], 3)
+            native_keys = list(payload)
+            self.assertLess(native_keys.index("acceleration"), native_keys.index("itemId"))
+            self.assertLess(native_keys.index("defensiveworkrate"), native_keys.index("itemId"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/extract_fifa14_cards_db_meta.ps1
+++ b/tools/extract_fifa14_cards_db_meta.ps1
@@ -1,0 +1,22 @@
+param(
+    [string]$GameRoot,
+    [string]$GameExe,
+    [string]$OutputDirectory
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+. (Join-Path $PSScriptRoot "common.ps1")
+
+$config = Resolve-Fifa14Paths -GameRoot $GameRoot -GameExe $GameExe
+$projectDir = Get-ProjectRoot
+$python = Resolve-ProjectPython
+$extractor = Join-Path $PSScriptRoot "extract_fifa14_cards_db_meta.py"
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $projectDir "artifacts\cards-ng-db-descriptor"
+}
+
+& $python $extractor --game-root $config.GameRoot --output $OutputDirectory
+if ($LASTEXITCODE -ne 0) {
+    throw "FIFA 14 cards_ng_db descriptor extraction failed."
+}

--- a/tools/extract_fifa14_cards_db_meta.py
+++ b/tools/extract_fifa14_cards_db_meta.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Extract FIFA 14's cards_ng_db descriptor XML without modifying game files."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from patch_fifa14_fut_legends_db import (
+    discover_descriptor_record,
+    pair_descriptor,
+    parse_descriptor,
+)
+
+
+META_NAMES = ("cards_ng_db-meta.xml", "cards_ng_db_meta.xml", "fifa_ng_db-meta.xml")
+ARCHIVES = ("patch.big", "cards0.big")
+
+
+def sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest().upper()
+
+
+def find_descriptor(game_root: Path) -> tuple[bytes, dict[str, Any]]:
+    for name in META_NAMES:
+        path = game_root / "data" / "db" / name
+        if path.is_file():
+            return path.read_bytes(), {
+                "archive": None,
+                "entry": str(path),
+                "sourceKind": "loose",
+            }
+
+    for archive_name in ARCHIVES:
+        named = pair_descriptor(game_root, archive_name, META_NAMES)
+        if named is not None:
+            return named
+
+    for archive_name in ARCHIVES:
+        archive = game_root / archive_name
+        if not archive.is_file():
+            continue
+        discovered = discover_descriptor_record(archive, archive.with_suffix(".bh"))
+        if discovered is not None:
+            return discovered
+
+    raise RuntimeError("cards_ng_db descriptor XML was not found in the loose DB or supported FIFA archives")
+
+
+def descriptor_manifest(xml: bytes, source: dict[str, Any]) -> dict[str, Any]:
+    descriptor = parse_descriptor(xml)
+    tables: dict[str, Any] = {}
+    for table in descriptor.values():
+        key = table.name.lower()
+        if key in tables:
+            continue
+        tables[key] = {
+            "name": table.name,
+            "shortName": table.short_name,
+            "fields": [
+                {
+                    "name": field.name,
+                    "shortName": field.short_name,
+                    "rangeLow": field.range_low,
+                    "rangeHigh": field.range_high,
+                }
+                for field in table.fields.values()
+            ],
+        }
+    return {
+        "schema": "fifa14-cards-ng-db-descriptor-v1",
+        "readOnly": True,
+        "source": source,
+        "sha256": sha256(xml),
+        "tables": sorted(tables.values(), key=lambda table: table["name"].lower()),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Extract FIFA 14 cards_ng_db descriptor XML read-only")
+    parser.add_argument("--game-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True, help="Directory for cards_ng_db-meta.xml and manifest.json")
+    args = parser.parse_args()
+
+    game_root = args.game_root.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    xml, source = find_descriptor(game_root)
+    manifest = descriptor_manifest(xml, source)
+
+    output.mkdir(parents=True, exist_ok=True)
+    xml_path = output / "cards_ng_db-meta.xml"
+    manifest_path = output / "cards_ng_db-meta.manifest.json"
+    xml_path.write_bytes(xml)
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "xml": str(xml_path),
+        "manifest": str(manifest_path),
+        "tableCount": len(manifest["tables"]),
+        "source": source,
+    }))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/extract_fifa14_player_data.py
+++ b/tools/extract_fifa14_player_data.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Export FIFA 14 base player data from installed archives without writing them."""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from scan_fifa14_match_assets import parse_db_candidates, row_int, safe_rows
+from patch_fifa14_fut_legends_db import playername_map
+
+
+ARCHIVES = ("patch.big", "cards0.big")
+META_NAMES = ("cards_ng_db-meta.xml", "cards_ng_db_meta.xml", "fifa_ng_db-meta.xml")
+GAMEPLAY_FIELDS = (
+    "acceleration", "sprintspeed", "positioning", "finishing", "shotpower", "longshots", "volleys", "penalties",
+    "vision", "crossing", "freekickaccuracy", "shortpassing", "longpassing", "curve",
+    "agility", "balance", "reactions", "ballcontrol", "dribbling",
+    "interceptions", "headingaccuracy", "marking", "standingtackle", "slidingtackle",
+    "jumping", "stamina", "strength", "aggression",
+    "gkdiving", "gkhandling", "gkkicking", "gkreflexes", "gkpositioning",
+)
+TRAIT_FIELDS = (
+    "weakfootabilitytypecode", "skillmoves", "preferredfoot", "attackingworkrate", "defensiveworkrate",
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest().upper()
+
+
+def first_name(row: dict[str, Any], names: dict[int, str], key: str) -> str:
+    value = row_int(row, key, default=0)
+    return str(names.get(value, "")) if value > 0 else ""
+
+
+def build_export(parsed_dbs: list[tuple[Any, dict[str, Any]]], game_root: Path) -> dict[str, Any]:
+    resolved: dict[int, dict[str, Any]] = {}
+    diagnostics: list[dict[str, Any]] = []
+    for source_rank, (db, source) in enumerate(parsed_dbs):
+        players_table = db.table("players")
+        links_table = db.table("teamplayerlinks")
+        league_links_table = db.table("leagueteamlinks")
+        if players_table is None:
+            diagnostics.append({"source": source, "error": "players table missing"})
+            continue
+        names_by_id, _names_by_text = playername_map(db)
+        player_teams = {
+            row_int(row, "playerid"): row_int(row, "teamid")
+            for row in safe_rows(db, links_table)
+            if row_int(row, "playerid") > 0 and row_int(row, "teamid") > 0
+        } if links_table is not None else {}
+        team_leagues = {
+            row_int(row, "teamid"): row_int(row, "leagueid")
+            for row in safe_rows(db, league_links_table)
+            if row_int(row, "teamid") > 0 and row_int(row, "leagueid") > 0
+        } if league_links_table is not None else {}
+        exported = 0
+        for row in safe_rows(db, players_table):
+            asset_id = row_int(row, "playerid")
+            if asset_id <= 0:
+                continue
+            team_id = player_teams.get(asset_id, row_int(row, "teamid"))
+            league_id = team_leagues.get(team_id, row_int(row, "leagueid"))
+            card = {
+                "assetId": asset_id,
+                "name": first_name(row, names_by_id, "commonnameid") or first_name(row, names_by_id, "playerjerseynameid"),
+                "firstName": first_name(row, names_by_id, "firstnameid"),
+                "lastName": first_name(row, names_by_id, "lastnameid"),
+                "rating": row_int(row, "overallrating"),
+                "teamId": team_id,
+                "leagueId": league_id,
+                "nation": row_int(row, "nationality"),
+                "gameplayAttributes": {field: row_int(row, field) for field in GAMEPLAY_FIELDS},
+                "traits": {field: row_int(row, field) for field in TRAIT_FIELDS},
+            }
+            card["name"] = card["name"] or " ".join(value for value in (card["firstName"], card["lastName"]) if value).strip()
+            score = (1 if card["name"] else 0, 1 if team_id > 0 else 0, 1 if league_id > 0 else 0, -source_rank)
+            previous = resolved.get(asset_id)
+            if previous is None or tuple(previous["_score"]) < score:
+                card["_score"] = list(score)
+                resolved[asset_id] = card
+            exported += 1
+        diagnostics.append({
+            "source": source,
+            "playersRead": exported,
+            "playerTeamLinks": len(player_teams),
+            "teamLeagueLinks": len(team_leagues),
+        })
+    players = []
+    for player in resolved.values():
+        player.pop("_score", None)
+        players.append(player)
+    players.sort(key=lambda player: int(player["assetId"]))
+    archive_hashes = {
+        archive: sha256(game_root / archive)
+        for archive in ARCHIVES if (game_root / archive).is_file()
+    }
+    return {
+        "schema": "fifa14-player-data-v1",
+        "readOnly": True,
+        "gameRoot": str(game_root),
+        "archiveSha256": archive_hashes,
+        "gameplayFields": list(GAMEPLAY_FIELDS),
+        "traitFields": list(TRAIT_FIELDS),
+        "players": players,
+        "diagnostics": diagnostics,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Export full FIFA 14 player data read-only")
+    parser.add_argument("--game-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    game_root = args.game_root.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    parsed = parse_db_candidates(game_root, ARCHIVES, "cards_ng_db.db", META_NAMES, cards=True)
+    document = build_export(parsed, game_root)
+    if not document["players"]:
+        raise RuntimeError("could not extract any player rows from cards_ng_db")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(json.dumps({"output": str(output), "players": len(document["players"]), "sources": len(parsed)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/launch_fifa14_hub_store.ps1
+++ b/tools/launch_fifa14_hub_store.ps1
@@ -87,5 +87,19 @@ if (-not (Test-Path -LiteralPath $venvPython)) {
     }
 }
 
+$playerDataCache = Join-Path $projectDir "artifacts\fifa14-player-data-v1.json"
+$playerDataExtractor = Join-Path $PSScriptRoot "extract_fifa14_player_data.py"
+if (-not (Test-Path -LiteralPath $playerDataCache -PathType Leaf)) {
+    Write-Host "Player-data cache is missing; extracting it from the installed FIFA 14 database..." -ForegroundColor Cyan
+    New-Item -ItemType Directory -Path (Split-Path -Parent $playerDataCache) -Force | Out-Null
+    & $venvPython $playerDataExtractor --game-root $GameRoot --output $playerDataCache
+    if ($LASTEXITCODE -ne 0 -or -not (Test-Path -LiteralPath $playerDataCache -PathType Leaf)) {
+        throw "Could not generate the FIFA 14 player-data cache: $playerDataCache"
+    }
+    Write-Host "Generated FIFA 14 player-data cache." -ForegroundColor Green
+} else {
+    Write-Host "Using existing FIFA 14 player-data cache: $playerDataCache" -ForegroundColor DarkGray
+}
+
 & (Join-Path $PSScriptRoot "run_fifa14_local_beta.ps1") -GameRoot $GameRoot -GameExe $GameExe
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }


### PR DESCRIPTION
WARNING: OPENING THE PR TO ASK FOR HELP, because this attribute stuff is driving me mad.

TODO: Doesn't work perfectly yet: some attributes are patched way too high, some are patched way too low, some not at all

Testing: After server starts, open http://127.0.0.1:8099/local-editor/,  create a card and add it to your club. In the menu it will have the default stats, if you see the in-game bio you will see some of the correct stats, while others will be a bit out of wack.

## What changed?


- Implemented app.css for styling the editor interface.
- Developed app.js to handle player card creation, editing, and searching functionalities.
- Created index.html for the main structure of the FUT Workshop editor.
- Introduced player_data.py to validate and load player data from the FIFA 14 cache.
- Added unit tests for custom card functionalities in test_custom_cards.py.
- Developed PowerShell script to extract FIFA 14 cards database metadata.
- Created Python script to export FIFA 14 base player data from installed archives.

## Testing

- [x] Python files compile successfully.
- [x] Opening http://127.0.0.1:8099/local-editor/ after the server is started will open the FUT Workshop editor
- [x] It's possible to search for a player, generate a card from there, the new card appears in game
- [ ] Stats reflect exactly what put in editor
- [x] I did not add generated runtime state, certificates, secrets, or EA game files.
- [ ] I documented any FIFA/runtime test I performed.

## Runtime test notes

Describe the exact FIFA 14/FUT flow tested, if applicable.
